### PR TITLE
feat: añadir endpoints de filtro por duración, rating y top 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.6.0</version>
+			<version>2.3.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/indimetra/auth/SpringSecurityConfig.java
+++ b/src/main/java/indimetra/auth/SpringSecurityConfig.java
@@ -47,6 +47,13 @@ public class SpringSecurityConfig {
                 .cors(Customizer.withDefaults())
 
                 .authorizeHttpRequests(authorize -> authorize
+                        // SWAGGER - permitir acceso sin autenticación
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
+    
                         // AUTHORIZATION
                         .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/register").permitAll()
                         .requestMatchers(HttpMethod.GET, "/auth/me").authenticated()
@@ -55,6 +62,12 @@ public class SpringSecurityConfig {
                         // Rutas públicas
                         .requestMatchers(HttpMethod.GET,
                                 "/cortometraje",
+                                "/cortometraje/buscar/{title}",
+                                "/cortometraje/buscar/categoria/{categoryName}",
+                                "/cortometraje/buscar/latest",
+                                "/cortometraje/buscar/rating-minimo/{valor}",
+                                "/cortometraje/buscar/top5-mejor-valorados",
+                                "/cortometraje/buscar/duracion-maxima/{minutos}",
                                 "/cortometraje/paginated",
                                 "/cortometraje/{id}")
                         .permitAll()

--- a/src/main/java/indimetra/modelo/repository/ICortometrajeRepository.java
+++ b/src/main/java/indimetra/modelo/repository/ICortometrajeRepository.java
@@ -1,6 +1,7 @@
 package indimetra.modelo.repository;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -12,10 +13,23 @@ import indimetra.modelo.entity.Cortometraje;
 
 public interface ICortometrajeRepository extends JpaRepository<Cortometraje, Long> {
 
-    //Hay que hacer pruebas para ver si funciona
     @Modifying
     @Transactional
     @Query("UPDATE Cortometraje c SET c.rating = :rating WHERE c.id = :id")
     void updateRating(@Param("id") Long id, @Param("rating") BigDecimal rating);
-    
+
+    @Query("SELECT c FROM Cortometraje c WHERE LOWER(c.title) LIKE LOWER(CONCAT('%', :title, '%'))")
+    List<Cortometraje> findByTitleContainingIgnoreCase(@Param("title") String title);
+
+    @Query("SELECT c FROM Cortometraje c WHERE LOWER(c.category.name) = LOWER(:categoryName)")
+    List<Cortometraje> findByCategoryNameIgnoreCase(@Param("categoryName") String categoryName);
+
+    List<Cortometraje> findByRatingGreaterThanEqual(BigDecimal rating);
+
+    List<Cortometraje> findTop5ByOrderByCreatedAtDesc();
+
+    List<Cortometraje> findTop5ByOrderByRatingDesc();
+
+    List<Cortometraje> findByDurationLessThanEqual(Integer duration);
+
 }

--- a/src/main/java/indimetra/modelo/service/CortometrajeServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/CortometrajeServiceImplMy8.java
@@ -27,33 +27,23 @@ public class CortometrajeServiceImplMy8 extends GenericoCRUDServiceImplMy8<Corto
     }
 
     @Override
-    public Optional<Cortometraje> findByName(String name) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'findByName'");
-    }
-
-    @Override
-    public List<Cortometraje> findByCategory(String category) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'findByCategory'");
+    public List<Cortometraje> findByCategory(String categoryName) {
+        return cortometrajeRepository.findByCategoryNameIgnoreCase(categoryName);
     }
 
     @Override
     public List<Cortometraje> findByRating(Double rating) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'findByRating'");
+        return cortometrajeRepository.findByRatingGreaterThanEqual(BigDecimal.valueOf(rating));
     }
 
     @Override
-    public Optional<Cortometraje> findByTitle(String title) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'findByTitle'");
+    public List<Cortometraje> findByTitleContainingIgnoreCase(String title) {
+        return cortometrajeRepository.findByTitleContainingIgnoreCase(title);
     }
 
     @Override
     public List<Cortometraje> findLatestSeries() {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'findLatestSeries'");
+        return cortometrajeRepository.findTop5ByOrderByCreatedAtDesc();
     }
 
     @Override
@@ -83,6 +73,16 @@ public class CortometrajeServiceImplMy8 extends GenericoCRUDServiceImplMy8<Corto
     @Override
     public Page<Cortometraje> findAll(Pageable pageable) {
         return cortometrajeRepository.findAll(pageable);
+    }
+
+    @Override
+    public List<Cortometraje> findTopRated() {
+        return cortometrajeRepository.findTop5ByOrderByRatingDesc();
+    }
+
+    @Override
+    public List<Cortometraje> findByDuracionMenorOIgual(Integer minutos) {
+        return cortometrajeRepository.findByDurationLessThanEqual(minutos);
     }
 
 }

--- a/src/main/java/indimetra/modelo/service/ICortometrajeService.java
+++ b/src/main/java/indimetra/modelo/service/ICortometrajeService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
 
 import indimetra.modelo.entity.Cortometraje;
 import indimetra.modelo.entity.User;
@@ -16,16 +17,18 @@ public interface ICortometrajeService extends IGenericoCRUD<Cortometraje, Long> 
 
     void updateRating(Long id, BigDecimal rating);
 
-    Optional<Cortometraje> findByName(String name);
-
     List<Cortometraje> findByCategory(String category);
 
     List<Cortometraje> findByRating(Double rating);
 
-    Optional<Cortometraje> findByTitle(String title);
+    List<Cortometraje> findByTitleContainingIgnoreCase(@Param("title") String title);
 
     List<Cortometraje> findLatestSeries();
 
     Optional<Cortometraje> findByIdIfOwnerOrAdmin(Long id, User usuario);
+
+    List<Cortometraje> findTopRated();
+
+    List<Cortometraje> findByDuracionMenorOIgual(Integer minutos);
 
 }

--- a/src/main/java/indimetra/restcontroller/CortometrajeRestcontroller.java
+++ b/src/main/java/indimetra/restcontroller/CortometrajeRestcontroller.java
@@ -7,10 +7,11 @@ import java.util.stream.Collectors;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -86,6 +87,95 @@ public class CortometrajeRestcontroller {
                 CortometrajeResponseDto response = modelMapper.map(cortometraje, CortometrajeResponseDto.class);
 
                 return ResponseEntity.status(200).body(response);
+        }
+
+        @GetMapping("/buscar/{title}")
+        public ResponseEntity<List<CortometrajeResponseDto>> buscarPorNombre(@PathVariable String title) {
+                List<Cortometraje> cortometrajes = cortometrajeService.findByTitleContainingIgnoreCase(title);
+
+                if (cortometrajes.isEmpty()) {
+                        throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                        "No se encontraron cortometrajes que coincidan con: " + title);
+                }
+
+                List<CortometrajeResponseDto> responseList = cortometrajes.stream()
+                                .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
+                                .toList();
+
+                return ResponseEntity.ok(responseList);
+        }
+
+        @GetMapping("/buscar/categoria/{categoryName}")
+        public ResponseEntity<List<CortometrajeResponseDto>> buscarPorCategoria(@PathVariable String categoryName) {
+                List<Cortometraje> cortos = cortometrajeService.findByCategory(categoryName);
+
+                if (cortos.isEmpty()) {
+                        throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                        "No se encontraron cortometrajes en la categoría: " + categoryName);
+                }
+
+                List<CortometrajeResponseDto> response = cortos.stream()
+                                .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
+                                .toList();
+
+                return ResponseEntity.ok(response);
+        }
+
+        @GetMapping("/buscar/latest")
+        public ResponseEntity<List<CortometrajeResponseDto>> obtenerTop5Nuevos() {
+                List<Cortometraje> cortos = cortometrajeService.findLatestSeries();
+
+                List<CortometrajeResponseDto> response = cortos.stream()
+                                .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
+                                .toList();
+
+                return ResponseEntity.ok(response);
+        }
+
+        // {{Valor}} solo numeros enteros
+        @GetMapping("/buscar/rating-minimo/{valor}")
+        public ResponseEntity<List<CortometrajeResponseDto>> obtenerCortometrajesConRatingMinimo(
+                        @PathVariable Double valor) {
+                List<Cortometraje> cortos = cortometrajeService.findByRating(valor);
+
+                if (cortos.isEmpty()) {
+                        throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                        "No se encontraron cortometrajes con rating >= " + valor);
+                }
+
+                List<CortometrajeResponseDto> response = cortos.stream()
+                                .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
+                                .toList();
+
+                return ResponseEntity.ok(response);
+        }
+
+        @GetMapping("/buscar/top5-mejor-valorados")
+        public ResponseEntity<List<CortometrajeResponseDto>> obtenerTop5MejorValorados() {
+                List<Cortometraje> top = cortometrajeService.findTopRated();
+
+                List<CortometrajeResponseDto> response = top.stream()
+                                .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
+                                .toList();
+
+                return ResponseEntity.ok(response);
+        }
+
+        @GetMapping("/buscar/duracion-maxima/{minutos}")
+        public ResponseEntity<List<CortometrajeResponseDto>> buscarPorDuracionMaxima(@PathVariable Integer minutos) {
+                List<Cortometraje> cortos = cortometrajeService.findByDuracionMenorOIgual(minutos);
+
+                if (cortos.isEmpty()) {
+                        throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                        "No se encontraron cortometrajes con duración menor o igual a " + minutos
+                                                        + " minutos");
+                }
+
+                List<CortometrajeResponseDto> response = cortos.stream()
+                                .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
+                                .toList();
+
+                return ResponseEntity.ok(response);
         }
 
         @PostMapping

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,5 @@ spring.jpa.show-sql=true
 logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate.SQL=DEBUG
 # logging.level.org.springframework.security=DEBUG
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true


### PR DESCRIPTION
Este Pull Request incorpora tres nuevos endpoints al CortometrajeRestcontroller, con el objetivo de mejorar las funcionalidades de búsqueda y filtrado para los usuarios:

Nuevas funcionalidades implementadas:
GET /cortometraje/buscar/rating-minimo/{valor}
Devuelve todos los cortometrajes con una valoración igual o superior al valor proporcionado.

GET /cortometraje/buscar/top5-mejor-valorados
Devuelve los cinco cortometrajes con mejor puntuación de todos los tiempos.

GET /cortometraje/buscar/duracion-maxima/{minutos}
Devuelve todos los cortometrajes cuya duración es menor o igual al número de minutos indicado.

Detalles técnicos
Se han añadido los métodos correspondientes en la interfaz ICortometrajeService y su implementación.

Las respuestas se mapean utilizando ModelMapper.

Se gestiona correctamente el caso en que no se encuentren resultados, devolviendo un código HTTP 404 mediante ResponseStatusException.