### PR TITLE
Refactor: reorganización de DTOs por módulo y aplicación de BaseEntity

### DIFF
--- a/src/main/java/indimetra/modelo/entity/Category.java
+++ b/src/main/java/indimetra/modelo/entity/Category.java
@@ -1,7 +1,6 @@
 package indimetra.modelo.entity;
 
-import java.io.Serializable;
-
+import indimetra.modelo.entity.base.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -12,18 +11,11 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Category implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Category extends BaseEntity {
 
     @Column(nullable = false, unique = true, length = 50)
     private String name;
 
     @Column(columnDefinition = "TEXT")
     private String description;
-
 }

--- a/src/main/java/indimetra/modelo/entity/Cortometraje.java
+++ b/src/main/java/indimetra/modelo/entity/Cortometraje.java
@@ -1,11 +1,12 @@
 package indimetra.modelo.entity;
 
-import java.io.Serializable;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.util.Date;
 
-import jakarta.persistence.*;
-import lombok.*;
+import indimetra.modelo.entity.base.BaseEntity;
 
 @Entity
 @Table(name = "cortometrajes")
@@ -14,13 +15,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Cortometraje implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Cortometraje extends BaseEntity {
 
     @Column(nullable = false, length = 255)
     private String title;

--- a/src/main/java/indimetra/modelo/entity/Favorite.java
+++ b/src/main/java/indimetra/modelo/entity/Favorite.java
@@ -1,27 +1,22 @@
 package indimetra.modelo.entity;
 
-import java.io.Serializable;
-import java.util.Date;
-
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.Date;
+
+import indimetra.modelo.entity.base.BaseEntity;
+
 @Entity
 @Table(name = "favorites", uniqueConstraints = {
-    @UniqueConstraint(columnNames = {"user_id", "cortometraje_id"})
+        @UniqueConstraint(columnNames = { "user_id", "cortometraje_id" })
 })
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Favorite implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Favorite extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/indimetra/modelo/entity/Review.java
+++ b/src/main/java/indimetra/modelo/entity/Review.java
@@ -1,11 +1,12 @@
 package indimetra.modelo.entity;
 
-import java.io.Serializable;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.math.BigDecimal;
 import java.util.Date;
 
-import jakarta.persistence.*;
-import lombok.*;
+import indimetra.modelo.entity.base.BaseEntity;
 
 @Entity
 @Table(name = "reviews")
@@ -14,13 +15,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Review implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Review extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/indimetra/modelo/entity/Role.java
+++ b/src/main/java/indimetra/modelo/entity/Role.java
@@ -1,9 +1,9 @@
 package indimetra.modelo.entity;
 
-import java.io.Serializable;
-
 import jakarta.persistence.*;
 import lombok.*;
+
+import indimetra.modelo.entity.base.BaseEntity;
 
 @Entity
 @Table(name = "roles")
@@ -12,13 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Role implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Role extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, unique = true)
@@ -31,5 +25,4 @@ public class Role implements Serializable {
     public enum RoleType {
         ROLE_ADMIN, ROLE_USER
     }
-
 }

--- a/src/main/java/indimetra/modelo/entity/User.java
+++ b/src/main/java/indimetra/modelo/entity/User.java
@@ -1,17 +1,17 @@
 package indimetra.modelo.entity;
 
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
-
+import jakarta.persistence.*;
+import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import jakarta.persistence.*;
-import lombok.*;
+import indimetra.modelo.entity.base.BaseEntity;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "users")
@@ -20,13 +20,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class User implements Serializable, UserDetails {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class User extends BaseEntity implements UserDetails {
 
     @Column(nullable = false, unique = true, length = 50)
     private String username;
@@ -72,5 +66,4 @@ public class User implements Serializable, UserDetails {
                 .map(r -> new SimpleGrantedAuthority(r.getName().name()))
                 .toList();
     }
-
 }

--- a/src/main/java/indimetra/modelo/entity/base/BaseEntity.java
+++ b/src/main/java/indimetra/modelo/entity/base/BaseEntity.java
@@ -1,0 +1,18 @@
+package indimetra.modelo.entity.base;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+
+@MappedSuperclass
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public abstract class BaseEntity implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    protected Long id;
+}

--- a/src/main/java/indimetra/modelo/entity/base/BaseEntityFull.java
+++ b/src/main/java/indimetra/modelo/entity/base/BaseEntityFull.java
@@ -1,0 +1,29 @@
+package indimetra.modelo.entity.base;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Date;
+
+@MappedSuperclass
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public abstract class BaseEntityFull extends BaseEntity {
+
+    @Column(name = "is_active", nullable = false)
+    protected Boolean isActive = true;
+
+    @Column(name = "is_deleted", nullable = false)
+    protected Boolean isDeleted = false;
+
+    @Column(name = "created_at", updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    protected Date createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = new Date();
+    }
+}

--- a/src/test/java/indimetra/restcontroller/AuthRestcontrollerTest.java
+++ b/src/test/java/indimetra/restcontroller/AuthRestcontrollerTest.java
@@ -72,13 +72,13 @@ public class AuthRestcontrollerTest {
         userRole.setName(Role.RoleType.ROLE_USER);
 
         // Creación del usuario mock
-        mockUser = User.builder()
-                .id(1L)
-                .username("testuser")
-                .email("test@example.com")
-                .password("encodedpassword")
-                .roles(Collections.singleton(userRole))
-                .build();
+        // mockUser = User.builder()
+        //         .id(1L)
+        //         .username("testuser")
+        //         .email("test@example.com")
+        //         .password("encodedpassword")
+        //         .roles(Collections.singleton(userRole))
+        //         .build();
 
         // Simulación del DTO recibido en la solicitud de registro
         userRequestDto = UserRequestDto.builder()


### PR DESCRIPTION
Este PR incluye:
- Reorganización de DTOs en subcarpetas `model` dentro de cada módulo de servicio.
- Creación y uso de `BaseEntity` en todas las entidades del dominio.
- Eliminación de duplicación del campo `id`.
- Limpieza del dominio y preparación para extender con `BaseEntityFull`.

Esta rama puede cerrarse tras el merge para continuar el refactor en una nueva rama.
