### PR TITLE
refactor: entidades actualizadas para extender de BaseEntityCreated

### DIFF
--- a/src/main/java/indimetra/modelo/entity/Cortometraje.java
+++ b/src/main/java/indimetra/modelo/entity/Cortometraje.java
@@ -4,9 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
-import java.util.Date;
 
-import indimetra.modelo.entity.base.BaseEntity;
+import indimetra.modelo.entity.base.BaseEntityCreated;
 
 @Entity
 @Table(name = "cortometrajes")
@@ -15,7 +14,7 @@ import indimetra.modelo.entity.base.BaseEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Cortometraje extends BaseEntity {
+public class Cortometraje extends BaseEntityCreated {
 
     @Column(nullable = false, length = 255)
     private String title;
@@ -52,15 +51,10 @@ public class Cortometraje extends BaseEntity {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
-    @Column(name = "created_at", updatable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date createdAt;
-
     @PrePersist
     protected void onCreate() {
         if (this.language == null) {
             this.language = "Spanish";
         }
-        this.createdAt = new Date();
     }
 }

--- a/src/main/java/indimetra/modelo/entity/Review.java
+++ b/src/main/java/indimetra/modelo/entity/Review.java
@@ -4,9 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
-import java.util.Date;
 
-import indimetra.modelo.entity.base.BaseEntity;
+import indimetra.modelo.entity.base.BaseEntityCreated;
 
 @Entity
 @Table(name = "reviews")
@@ -15,7 +14,7 @@ import indimetra.modelo.entity.base.BaseEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Review extends BaseEntity {
+public class Review extends BaseEntityCreated {
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
@@ -30,15 +29,4 @@ public class Review extends BaseEntity {
 
     @Column(columnDefinition = "TEXT")
     private String comment;
-
-    @Column(name = "created_at", updatable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date createdAt;
-
-    @PrePersist
-    protected void onCreate() {
-        if (this.createdAt == null) {
-            this.createdAt = new Date();
-        }
-    }
 }

--- a/src/main/java/indimetra/modelo/entity/User.java
+++ b/src/main/java/indimetra/modelo/entity/User.java
@@ -6,10 +6,9 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import indimetra.modelo.entity.base.BaseEntity;
+import indimetra.modelo.entity.base.BaseEntityCreated;
 
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -20,7 +19,7 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class User extends BaseEntity implements UserDetails {
+public class User extends BaseEntityCreated implements UserDetails {
 
     @Column(nullable = false, unique = true, length = 50)
     private String username;
@@ -44,21 +43,10 @@ public class User extends BaseEntity implements UserDetails {
     @Column(nullable = false, length = 50)
     private String country;
 
-    @Column(name = "created_at", updatable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date createdAt;
-
     @Builder.Default
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"), inverseJoinColumns = @JoinColumn(name = "role_id"))
     private Set<Role> roles = new HashSet<>();
-
-    @PrePersist
-    protected void onCreate() {
-        if (this.createdAt == null) {
-            this.createdAt = new Date();
-        }
-    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/indimetra/modelo/entity/base/BaseEntityCreated.java
+++ b/src/main/java/indimetra/modelo/entity/base/BaseEntityCreated.java
@@ -1,0 +1,23 @@
+package indimetra.modelo.entity.base;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Date;
+
+@MappedSuperclass
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public abstract class BaseEntityCreated extends BaseEntity {
+
+    @Column(name = "created_at", updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    protected Date createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = new Date();
+    }
+}


### PR DESCRIPTION
Este Pull Request realiza una mejora estructural en las entidades del dominio aplicando el uso de una clase base común para centralizar la lógica de creación.

### Cambios principales:

- Se crea la clase `BaseEntityCreated`, que extiende de `BaseEntity` e incluye el campo `createdAt` con anotaciones JPA y lógica en `@PrePersist`.
- Las entidades `User`, `Cortometraje`, `Review` y `Favorite` ahora extienden de `BaseEntityCreated`.
- Se elimina la duplicación del campo `createdAt` y su lógica repetida en cada entidad.
- Se mantiene el campo `addedAt` en `Favorite` ya que es independiente de `createdAt`.

### Beneficios:

- Mayor reutilización de código.
- Lógica de persistencia unificada.
- Mejora en la legibilidad y mantenimiento de las entidades.

Esta refactorización deja el camino preparado para implementar en el futuro una clase `BaseEntityFull` que incluya campos como `isActive`, `isDeleted`, etc.
