### PR TITLE
Refactorizar CategoryServiceImplMy8 utilizando arquitectura genérica con DTOs

### DIFF
--- a/src/main/java/indimetra/exception/BadRequestException.java
+++ b/src/main/java/indimetra/exception/BadRequestException.java
@@ -1,0 +1,11 @@
+package indimetra.exception;
+
+import org.springframework.http.HttpStatus;
+
+import indimetra.exception.base.BaseApiException;
+
+public class BadRequestException extends BaseApiException {
+    public BadRequestException(String message) {
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/indimetra/exception/ConflictException.java
+++ b/src/main/java/indimetra/exception/ConflictException.java
@@ -1,0 +1,11 @@
+package indimetra.exception;
+
+import org.springframework.http.HttpStatus;
+
+import indimetra.exception.base.BaseApiException;
+
+public class ConflictException extends BaseApiException {
+    public ConflictException(String message) {
+        super(message, HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/indimetra/exception/ForbiddenException.java
+++ b/src/main/java/indimetra/exception/ForbiddenException.java
@@ -1,0 +1,11 @@
+package indimetra.exception;
+
+import org.springframework.http.HttpStatus;
+
+import indimetra.exception.base.BaseApiException;
+
+public class ForbiddenException extends BaseApiException {
+    public ForbiddenException(String message) {
+        super(message, HttpStatus.FORBIDDEN);
+    }
+}

--- a/src/main/java/indimetra/exception/NotFoundException.java
+++ b/src/main/java/indimetra/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+package indimetra.exception;
+
+import org.springframework.http.HttpStatus;
+
+import indimetra.exception.base.BaseApiException;
+
+public class NotFoundException extends BaseApiException {
+    public NotFoundException(String message) {
+        super(message, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/indimetra/exception/UnauthorizedException.java
+++ b/src/main/java/indimetra/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package indimetra.exception;
+
+import org.springframework.http.HttpStatus;
+
+import indimetra.exception.base.BaseApiException;
+
+public class UnauthorizedException extends BaseApiException {
+    public UnauthorizedException(String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/indimetra/exception/base/BaseApiException.java
+++ b/src/main/java/indimetra/exception/base/BaseApiException.java
@@ -1,0 +1,15 @@
+package indimetra.exception.base;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BaseApiException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    public BaseApiException(String message, HttpStatus status) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/src/main/java/indimetra/modelo/helpers/Validators.java
+++ b/src/main/java/indimetra/modelo/helpers/Validators.java
@@ -1,0 +1,31 @@
+package indimetra.modelo.helpers;
+
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+public class Validators {
+
+    public static boolean isValidEmail(String email) {
+        if (email == null)
+            return false;
+
+        String trimmedEmail = email.trim();
+
+        // No debe terminar en punto
+        if (trimmedEmail.endsWith("."))
+            return false;
+
+        String emailRegex = "^([0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z])*@([0-9a-zA-Z][-\\w]*[0-9a-zA-Z]\\.)+[a-zA-Z]{2,9})$";
+        Pattern pattern = Pattern.compile(emailRegex);
+        Matcher matcher = pattern.matcher(trimmedEmail);
+
+        try {
+            if (!matcher.matches()) {
+                throw new IllegalArgumentException("Email no válido según el patrón.");
+            }
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/indimetra/modelo/service/Base/GenericDtoServiceImpl.java
+++ b/src/main/java/indimetra/modelo/service/Base/GenericDtoServiceImpl.java
@@ -1,0 +1,75 @@
+package indimetra.modelo.service.Base;
+
+import java.util.List;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import indimetra.exception.NotFoundException;
+
+public abstract class GenericDtoServiceImpl<
+    TEntity, 
+    TRequestDto, 
+    TResponseDto, 
+    ID> implements IGenericDtoService<TEntity, TRequestDto, TResponseDto, ID> {
+
+    @Autowired
+    protected ModelMapper modelMapper;
+
+    protected abstract JpaRepository<TEntity, ID> getRepository();
+
+    protected abstract Class<TEntity> getEntityClass();
+    protected abstract Class<TRequestDto> getRequestDtoClass();
+    protected abstract Class<TResponseDto> getResponseDtoClass();
+
+    @Override
+    public List<TResponseDto> findAll() {
+        return getRepository().findAll().stream()
+            .map(entity -> modelMapper.map(entity, getResponseDtoClass()))
+            .toList();
+    }
+
+    @Override
+    public TResponseDto findById(ID id) {
+        TEntity entity = getRepository().findById(id)
+            .orElseThrow(() -> new NotFoundException("Entidad no encontrada con ID: " + id));
+
+        return modelMapper.map(entity, getResponseDtoClass());
+    }
+
+    @Override
+    public TResponseDto create(TRequestDto dto) {
+        TEntity entity = modelMapper.map(dto, getEntityClass());
+        TEntity saved = getRepository().save(entity);
+        return modelMapper.map(saved, getResponseDtoClass());
+    }
+
+    @Override
+    public TResponseDto update(ID id, TRequestDto dto) {
+        if (!getRepository().existsById(id)) {
+            throw new NotFoundException("Entidad no encontrada con ID: " + id);
+        }
+
+        TEntity entity = modelMapper.map(dto, getEntityClass());
+        setEntityId(entity, id);
+        TEntity updated = getRepository().save(entity);
+
+        return modelMapper.map(updated, getResponseDtoClass());
+    }
+
+    @Override
+    public void delete(ID id) {
+        if (!getRepository().existsById(id)) {
+            throw new NotFoundException("Entidad no encontrada con ID: " + id);
+        }
+
+        getRepository().deleteById(id);
+    }
+
+    /**
+     * Método que debes implementar en cada servicio concreto para asignar el ID al entity antes de actualizar.
+     */
+    protected abstract void setEntityId(TEntity entity, ID id);
+}
+

--- a/src/main/java/indimetra/modelo/service/Base/GenericoCRUDServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/Base/GenericoCRUDServiceImplMy8.java
@@ -1,16 +1,14 @@
 package indimetra.modelo.service.Base;
 
-import java.util.List;
-import java.util.Optional;
-
+import indimetra.exception.BadRequestException;
+import indimetra.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
-
-import jakarta.persistence.EntityNotFoundException;
-
-import org.hibernate.service.spi.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
 
 public abstract class GenericoCRUDServiceImplMy8<E, ID> implements IGenericoCRUD<E, ID> {
 
@@ -24,7 +22,7 @@ public abstract class GenericoCRUDServiceImplMy8<E, ID> implements IGenericoCRUD
             return getRepository().findAll();
         } catch (Exception e) {
             LOGGER.error("Error al recuperar todos los registros: {}", e.getMessage(), e);
-            throw new ServiceException("Error al recuperar todos los registros", e);
+            throw new RuntimeException("Error interno al recuperar todos los registros");
         }
     }
 
@@ -32,7 +30,7 @@ public abstract class GenericoCRUDServiceImplMy8<E, ID> implements IGenericoCRUD
     @Transactional
     public E create(E entity) {
         if (entity == null) {
-            throw new IllegalArgumentException("La entidad no puede ser nula");
+            throw new BadRequestException("La entidad no puede ser nula");
         }
 
         try {
@@ -40,21 +38,21 @@ public abstract class GenericoCRUDServiceImplMy8<E, ID> implements IGenericoCRUD
             return getRepository().save(entity);
         } catch (Exception e) {
             LOGGER.error("Error al crear la entidad: {}", e.getMessage(), e);
-            throw new ServiceException("Error al crear la entidad", e);
+            throw new RuntimeException("Error interno al crear la entidad");
         }
     }
 
     @Override
     public Optional<E> read(ID id) {
         if (id == null) {
-            throw new IllegalArgumentException("El ID no puede ser nulo");
+            throw new BadRequestException("El ID no puede ser nulo");
         }
 
         try {
             return getRepository().findById(id);
         } catch (Exception e) {
             LOGGER.error("Error al recuperar entidad por ID: {}", e.getMessage(), e);
-            throw new ServiceException("Error al recuperar entidad por ID", e);
+            throw new RuntimeException("Error interno al recuperar entidad por ID");
         }
     }
 
@@ -62,7 +60,7 @@ public abstract class GenericoCRUDServiceImplMy8<E, ID> implements IGenericoCRUD
     @Transactional
     public E update(E entity) {
         if (entity == null) {
-            throw new IllegalArgumentException("La entidad no puede ser nula");
+            throw new BadRequestException("La entidad no puede ser nula");
         }
 
         try {
@@ -70,7 +68,7 @@ public abstract class GenericoCRUDServiceImplMy8<E, ID> implements IGenericoCRUD
             return getRepository().save(entity);
         } catch (Exception e) {
             LOGGER.error("Error al actualizar la entidad: {}", e.getMessage(), e);
-            throw new ServiceException("Error al actualizar la entidad", e);
+            throw new RuntimeException("Error interno al actualizar la entidad");
         }
     }
 
@@ -78,12 +76,12 @@ public abstract class GenericoCRUDServiceImplMy8<E, ID> implements IGenericoCRUD
     @Transactional
     public void delete(ID id) {
         if (id == null) {
-            throw new IllegalArgumentException("El ID no puede ser nulo");
+            throw new BadRequestException("El ID no puede ser nulo");
         }
 
         try {
             if (!getRepository().existsById(id)) {
-                throw new EntityNotFoundException("No se encontró la entidad con ID: " + id);
+                throw new NotFoundException("No se encontró la entidad con ID: " + id);
             }
 
             getRepository().deleteById(id);
@@ -91,7 +89,7 @@ public abstract class GenericoCRUDServiceImplMy8<E, ID> implements IGenericoCRUD
 
         } catch (Exception e) {
             LOGGER.error("Error al eliminar la entidad: {}", e.getMessage(), e);
-            throw new ServiceException("Error al eliminar la entidad", e);
+            throw new RuntimeException("Error interno al eliminar la entidad");
         }
     }
 }

--- a/src/main/java/indimetra/modelo/service/Base/IGenericDtoService.java
+++ b/src/main/java/indimetra/modelo/service/Base/IGenericDtoService.java
@@ -1,0 +1,21 @@
+package indimetra.modelo.service.Base;
+
+import java.util.List;
+
+public interface IGenericDtoService<
+    TEntity, 
+    TRequestDto, 
+    TResponseDto, 
+    ID> {
+
+    List<TResponseDto> findAll();
+
+    TResponseDto findById(ID id);
+
+    TResponseDto create(TRequestDto dto);
+
+    TResponseDto update(ID id, TRequestDto dto);
+
+    void delete(ID id);
+}
+

--- a/src/main/java/indimetra/modelo/service/Category/CategoryServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/Category/CategoryServiceImplMy8.java
@@ -5,12 +5,16 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import indimetra.exception.BadRequestException;
 import indimetra.modelo.entity.Category;
 import indimetra.modelo.repository.ICategoryRepository;
-import indimetra.modelo.service.Base.GenericoCRUDServiceImplMy8;
+import indimetra.modelo.service.Base.GenericDtoServiceImpl;
+import indimetra.modelo.service.Category.Model.CategoryRequestDto;
+import indimetra.modelo.service.Category.Model.CategoryResponseDto;
 
 @Service
-public class CategoryServiceImplMy8 extends GenericoCRUDServiceImplMy8<Category, Long> implements ICategoryService {
+public class CategoryServiceImplMy8 extends
+        GenericDtoServiceImpl<Category, CategoryRequestDto, CategoryResponseDto, Long> implements ICategoryService {
 
     @Autowired
     private ICategoryRepository categoryRepository;
@@ -21,7 +25,31 @@ public class CategoryServiceImplMy8 extends GenericoCRUDServiceImplMy8<Category,
     }
 
     @Override
+    protected Class<Category> getEntityClass() {
+        return Category.class;
+    }
+
+    @Override
+    protected Class<CategoryRequestDto> getRequestDtoClass() {
+        return CategoryRequestDto.class;
+    }
+
+    @Override
+    protected Class<CategoryResponseDto> getResponseDtoClass() {
+        return CategoryResponseDto.class;
+    }
+
+    // Usa en la lógica de actualización (update) para asignar manualmente el ID al entity, ya que los DTOs no lo tienen
+    @Override
+    protected void setEntityId(Category entity, Long id) {
+        entity.setId(id);
+    }
+
+    @Override
     public Optional<Category> findByName(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new BadRequestException("El nombre de la categoría no puede estar vacío");
+        }
         return categoryRepository.findByName(name);
     }
 }

--- a/src/main/java/indimetra/modelo/service/Category/ICategoryService.java
+++ b/src/main/java/indimetra/modelo/service/Category/ICategoryService.java
@@ -3,10 +3,11 @@ package indimetra.modelo.service.Category;
 import java.util.Optional;
 
 import indimetra.modelo.entity.Category;
-import indimetra.modelo.service.Base.IGenericoCRUD;
+import indimetra.modelo.service.Base.IGenericDtoService;
+import indimetra.modelo.service.Category.Model.CategoryRequestDto;
+import indimetra.modelo.service.Category.Model.CategoryResponseDto;
 
-public interface ICategoryService extends IGenericoCRUD<Category, Long> {
+public interface ICategoryService extends IGenericDtoService<Category, CategoryRequestDto, CategoryResponseDto, Long> {
 
     Optional<Category> findByName(String name);
-    
 }

--- a/src/main/java/indimetra/modelo/service/Favorite/FavoriteServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/Favorite/FavoriteServiceImplMy8.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import indimetra.exception.BadRequestException;
 import indimetra.modelo.entity.Favorite;
 import indimetra.modelo.repository.IFavoriteRepository;
 import indimetra.modelo.service.Base.GenericoCRUDServiceImplMy8;
@@ -22,17 +23,26 @@ public class FavoriteServiceImplMy8 extends GenericoCRUDServiceImplMy8<Favorite,
 
     @Override
     public List<Favorite> findByUserId(Long userId) {
+        if (userId == null || userId <= 0) {
+            throw new BadRequestException("El ID del usuario no puede ser nulo o menor a 1");
+        }
         return favoriteRepository.findByUserId(userId);
     }
 
     @Override
     public List<Favorite> findByUsername(String username) {
+        if (username == null || username.trim().isEmpty()) {
+            throw new BadRequestException("El nombre de usuario no puede estar vacío");
+        }
         return favoriteRepository.findByUserUsername(username);
     }
 
     @Override
     public boolean isFavoriteOwner(Long userId, Long cortometrajeId) {
+        if (userId == null || cortometrajeId == null) {
+            throw new BadRequestException("El ID del usuario y del cortometraje no pueden ser nulos");
+        }
+
         return favoriteRepository.findByUserIdAndCortometrajeId(userId, cortometrajeId).isPresent();
     }
-
 }

--- a/src/main/java/indimetra/modelo/service/Review/ReviewServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/Review/ReviewServiceImplMy8.java
@@ -6,6 +6,9 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import indimetra.exception.BadRequestException;
+import indimetra.exception.ForbiddenException;
+import indimetra.exception.NotFoundException;
 import indimetra.modelo.entity.Review;
 import indimetra.modelo.entity.User;
 import indimetra.modelo.repository.IReviewRepository;
@@ -28,8 +31,13 @@ public class ReviewServiceImplMy8 extends GenericoCRUDServiceImplMy8<Review, Lon
 
     @Override
     public boolean isReviewOwner(Long reviewId, Long userId) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'isReviewOwner'");
+        if (reviewId == null || userId == null) {
+            throw new BadRequestException("El ID de la review y del usuario no pueden ser nulos");
+        }
+
+        return read(reviewId)
+                .map(review -> review.getUser().getId().equals(userId))
+                .orElseThrow(() -> new NotFoundException("La review no fue encontrada"));
     }
 
     @Override
@@ -38,24 +46,39 @@ public class ReviewServiceImplMy8 extends GenericoCRUDServiceImplMy8<Review, Lon
         throw new UnsupportedOperationException("Unimplemented method 'existsByUserAndSeries'");
     }
 
+    @Override
     public void actualizarRatingCortometraje(Long cortometrajeId) {
+        if (cortometrajeId == null || cortometrajeId <= 0) {
+            throw new BadRequestException("El ID del cortometraje no es válido");
+        }
+
         BigDecimal promedio = reviewRepository.calcularPromedioRating(cortometrajeId);
         cortometrajeService.updateRating(cortometrajeId, promedio != null ? promedio : BigDecimal.ZERO);
     }
 
     @Override
     public boolean existsByUserAndCortometraje(Long userId, Long cortometrajeId) {
+        if (userId == null || userId <= 0 || cortometrajeId == null || cortometrajeId <= 0) {
+            throw new BadRequestException("Los IDs del usuario y del cortometraje deben ser válidos y mayores que 0");
+        }
+
         return reviewRepository.existsByUserIdAndCortometrajeId(userId, cortometrajeId);
     }
 
     @Override
     public Optional<Review> findByIdIfOwnerOrAdmin(Long id, User user) {
-        return read(id).filter(review -> {
-            boolean isAdmin = user.getRoles().stream()
-                    .anyMatch(r -> r.getName().name().equals("ROLE_ADMIN"));
-            boolean isOwner = review.getUser().getId().equals(user.getId());
-            return isAdmin || isOwner;
-        });
+        Review review = read(id)
+                .orElseThrow(() -> new NotFoundException("Review no encontrada con ID: " + id));
+
+        boolean isAdmin = user.getRoles().stream()
+                .anyMatch(r -> r.getName().name().equals("ROLE_ADMIN"));
+        boolean isOwner = review.getUser().getId().equals(user.getId());
+
+        if (!isAdmin && !isOwner) {
+            throw new ForbiddenException("No tienes permiso para acceder a esta review");
+        }
+
+        return Optional.of(review);
     }
 
 }

--- a/src/main/java/indimetra/modelo/service/Role/RoleServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/Role/RoleServiceImplMy8.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import indimetra.exception.BadRequestException;
+import indimetra.exception.NotFoundException;
 import indimetra.modelo.entity.Role;
 import indimetra.modelo.entity.Role.RoleType;
 import indimetra.modelo.repository.IRoleRepository;
@@ -23,12 +25,20 @@ public class RoleServiceImplMy8 extends GenericoCRUDServiceImplMy8<Role, Long> i
 
     @Override
     public Optional<Role> findByName(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new BadRequestException("El nombre del rol no puede estar vacío");
+        }
+
         try {
-            RoleType roleType = RoleType.valueOf(name);
+            RoleType roleType = RoleType.valueOf(name.toUpperCase());
             return roleRepository.findByName(roleType);
         } catch (IllegalArgumentException e) {
-            return Optional.empty();
+            throw new BadRequestException("El nombre del rol no es válido: " + name);
         }
     }
 
+    public Role findByNameOrThrow(String name) {
+        return findByName(name)
+                .orElseThrow(() -> new NotFoundException("Rol no encontrado: " + name));
+    }
 }

--- a/src/main/java/indimetra/modelo/service/User/IUserService.java
+++ b/src/main/java/indimetra/modelo/service/User/IUserService.java
@@ -4,13 +4,8 @@ import java.util.Optional;
 
 import indimetra.modelo.entity.User;
 import indimetra.modelo.service.Base.IGenericoCRUD;
-import indimetra.modelo.service.User.Model.UserRequestDto;
 
 public interface IUserService extends IGenericoCRUD<User, Long> {
-
-    User authenticateUser(String username, String password);
-
-    User registerUser(UserRequestDto userDto);
 
     void updateAuthorStatus(Long userId, boolean isAuthor);
 

--- a/src/main/java/indimetra/restcontroller/CategoryRestcontroller.java
+++ b/src/main/java/indimetra/restcontroller/CategoryRestcontroller.java
@@ -1,82 +1,54 @@
 package indimetra.restcontroller;
 
 import java.util.List;
-import java.util.Map;
 
-import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import indimetra.modelo.entity.Category;
 import indimetra.modelo.service.Category.ICategoryService;
 import indimetra.modelo.service.Category.Model.CategoryRequestDto;
 import indimetra.modelo.service.Category.Model.CategoryResponseDto;
+import indimetra.restcontroller.base.BaseRestcontroller;
+import indimetra.utils.ApiResponse;
 import jakarta.validation.Valid;
 
 @RestController
 @CrossOrigin(origins = "*")
 @RequestMapping("/category")
-public class CategoryRestcontroller {
-
-    @Autowired
-    private ModelMapper modelMapper;
+public class CategoryRestcontroller extends BaseRestcontroller {
 
     @Autowired
     private ICategoryService categoryService;
 
     @GetMapping
-    public ResponseEntity<List<CategoryResponseDto>> findAll() {
-        List<Category> categories = categoryService.findAll();
-
-        List<CategoryResponseDto> response = categories.stream()
-                .map(category -> modelMapper.map(category, CategoryResponseDto.class))
-                .toList();
-
-        return ResponseEntity.status(200).body(response);
+    public ResponseEntity<ApiResponse<List<CategoryResponseDto>>> findAll() {
+        List<CategoryResponseDto> response = categoryService.findAll();
+        return success(response, "Listado de categorías");
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<CategoryResponseDto> findById(@PathVariable Long id) {
-        Category category = categoryService.read(id)
-                .orElseThrow(() -> new RuntimeException("Categoria no encontrado"));
-
-        CategoryResponseDto response = modelMapper.map(category, CategoryResponseDto.class);
-        return ResponseEntity.status(200).body(response);
+    public ResponseEntity<ApiResponse<CategoryResponseDto>> findById(@PathVariable Long id) {
+        CategoryResponseDto response = categoryService.findById(id);
+        return success(response, "Categoría encontrada");
     }
 
     @PostMapping
-    public ResponseEntity<CategoryResponseDto> create(@RequestBody @Valid CategoryRequestDto dto) {
-        Category category = modelMapper.map(dto, Category.class);
-        Category saved = categoryService.create(category);
-        CategoryResponseDto response = modelMapper.map(saved, CategoryResponseDto.class);
-        return ResponseEntity.status(201).body(response);
+    public ResponseEntity<ApiResponse<CategoryResponseDto>> create(@RequestBody @Valid CategoryRequestDto dto) {
+        CategoryResponseDto response = categoryService.create(dto);
+        return created(response, "Categoría creada correctamente");
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<CategoryResponseDto> update(@PathVariable Long id, @RequestBody @Valid CategoryRequestDto dto) {
-
-        Category category = modelMapper.map(dto, Category.class);
-        category.setId(id);
-
-        Category updated = categoryService.update(category);
-        CategoryResponseDto response = modelMapper.map(updated, CategoryResponseDto.class);
-
-        return ResponseEntity.status(200).body(response);
+    public ResponseEntity<ApiResponse<CategoryResponseDto>> update(@PathVariable Long id,
+            @RequestBody @Valid CategoryRequestDto dto) {
+        CategoryResponseDto response = categoryService.update(id, dto);
+        return success(response, "Categoría actualizada correctamente");
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Map<String, String>> delete(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id) {
         categoryService.delete(id);
-        return ResponseEntity.ok(Map.of("message", "Categoría eliminada correctamente"));
+        return success(null, "Categoría eliminada correctamente");
     }
-
 }

--- a/src/main/java/indimetra/restcontroller/CortometrajeRestcontroller.java
+++ b/src/main/java/indimetra/restcontroller/CortometrajeRestcontroller.java
@@ -13,9 +13,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import indimetra.exception.ForbiddenException;
+import indimetra.exception.NotFoundException;
 import indimetra.modelo.entity.Category;
 import indimetra.modelo.entity.Cortometraje;
 import indimetra.modelo.entity.Role;
@@ -26,12 +27,14 @@ import indimetra.modelo.service.Cortometraje.Model.CortometrajeRequestDto;
 import indimetra.modelo.service.Cortometraje.Model.CortometrajeResponseDto;
 import indimetra.modelo.service.Shared.Model.PagedResponse;
 import indimetra.modelo.service.User.IUserService;
+import indimetra.restcontroller.base.BaseRestcontroller;
+import indimetra.utils.ApiResponse;
 import jakarta.validation.Valid;
 
 @RestController
 @CrossOrigin(origins = "*")
 @RequestMapping("/cortometraje")
-public class CortometrajeRestcontroller {
+public class CortometrajeRestcontroller extends BaseRestcontroller {
 
         @Autowired
         private ICortometrajeService cortometrajeService;
@@ -46,14 +49,13 @@ public class CortometrajeRestcontroller {
         private ModelMapper modelMapper;
 
         @GetMapping
-        public ResponseEntity<List<CortometrajeResponseDto>> findAll() {
-                List<Cortometraje> cortometrajes = cortometrajeService.findAll();
+        public ResponseEntity<ApiResponse<List<CortometrajeResponseDto>>> findAll() {
+                List<CortometrajeResponseDto> response = cortometrajeService.findAll()
+                                .stream()
+                                .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
+                                .toList();
 
-                List<CortometrajeResponseDto> response = cortometrajes.stream()
-                                .map(cortometraje -> modelMapper.map(cortometraje, CortometrajeResponseDto.class))
-                                .collect(Collectors.toList());
-
-                return ResponseEntity.status(200).body(response);
+                return success(response, "Listado de cortometrajes");
         }
 
         @GetMapping("/paginated")
@@ -66,7 +68,7 @@ public class CortometrajeRestcontroller {
 
                 List<CortometrajeResponseDto> dtoList = pageResult.getContent().stream()
                                 .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
-                                .collect(Collectors.toList());
+                                .toList();
 
                 PagedResponse<CortometrajeResponseDto> response = PagedResponse.<CortometrajeResponseDto>builder()
                                 .message("Listado de cortometrajes paginado")
@@ -79,190 +81,185 @@ public class CortometrajeRestcontroller {
                 return ResponseEntity.ok(response);
         }
 
-        @GetMapping("{id}")
-        public ResponseEntity<CortometrajeResponseDto> read(@PathVariable Long id) {
+        @GetMapping("/{id}")
+        public ResponseEntity<ApiResponse<CortometrajeResponseDto>> read(@PathVariable Long id) {
                 Cortometraje cortometraje = cortometrajeService.read(id)
-                                .orElseThrow(() -> new RuntimeException("Cortometraje no encontrado"));
+                                .orElseThrow(() -> new NotFoundException("Cortometraje no encontrado con ID: " + id));
 
                 CortometrajeResponseDto response = modelMapper.map(cortometraje, CortometrajeResponseDto.class);
-
-                return ResponseEntity.status(200).body(response);
+                return success(response, "Cortometraje encontrado");
         }
 
         @GetMapping("/buscar/{title}")
-        public ResponseEntity<List<CortometrajeResponseDto>> buscarPorNombre(@PathVariable String title) {
-                List<Cortometraje> cortometrajes = cortometrajeService.findByTitleContainingIgnoreCase(title);
-
-                if (cortometrajes.isEmpty()) {
-                        throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                                        "No se encontraron cortometrajes que coincidan con: " + title);
-                }
-
-                List<CortometrajeResponseDto> responseList = cortometrajes.stream()
-                                .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
-                                .toList();
-
-                return ResponseEntity.ok(responseList);
-        }
-
-        @GetMapping("/buscar/categoria/{categoryName}")
-        public ResponseEntity<List<CortometrajeResponseDto>> buscarPorCategoria(@PathVariable String categoryName) {
-                List<Cortometraje> cortos = cortometrajeService.findByCategory(categoryName);
+        public ResponseEntity<ApiResponse<List<CortometrajeResponseDto>>> buscarPorNombre(@PathVariable String title) {
+                List<Cortometraje> cortos = cortometrajeService.findByTitleContainingIgnoreCase(title);
 
                 if (cortos.isEmpty()) {
-                        throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                                        "No se encontraron cortometrajes en la categoría: " + categoryName);
+                        throw new NotFoundException("No se encontraron cortometrajes que coincidan con: " + title);
                 }
 
                 List<CortometrajeResponseDto> response = cortos.stream()
                                 .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
                                 .toList();
 
-                return ResponseEntity.ok(response);
+                return success(response, "Resultados para el título: " + title);
+        }
+
+        @GetMapping("/buscar/categoria/{categoryName}")
+        public ResponseEntity<ApiResponse<List<CortometrajeResponseDto>>> buscarPorCategoria(
+                        @PathVariable String categoryName) {
+                List<Cortometraje> cortos = cortometrajeService.findByCategory(categoryName);
+
+                if (cortos.isEmpty()) {
+                        throw new NotFoundException("No se encontraron cortometrajes en la categoría: " + categoryName);
+                }
+
+                List<CortometrajeResponseDto> response = cortos.stream()
+                                .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
+                                .toList();
+
+                return success(response, "Cortometrajes encontrados en la categoría: " + categoryName);
         }
 
         @GetMapping("/buscar/latest")
-        public ResponseEntity<List<CortometrajeResponseDto>> obtenerTop5Nuevos() {
+        public ResponseEntity<ApiResponse<List<CortometrajeResponseDto>>> obtenerTop5Nuevos() {
                 List<Cortometraje> cortos = cortometrajeService.findLatestSeries();
 
                 List<CortometrajeResponseDto> response = cortos.stream()
                                 .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
                                 .toList();
 
-                return ResponseEntity.ok(response);
+                return success(response, "Top 5 más recientes");
         }
 
         // {{Valor}} solo numeros enteros
         @GetMapping("/buscar/rating-minimo/{valor}")
-        public ResponseEntity<List<CortometrajeResponseDto>> obtenerCortometrajesConRatingMinimo(
+        public ResponseEntity<ApiResponse<List<CortometrajeResponseDto>>> obtenerCortosConMinimoRating(
                         @PathVariable Double valor) {
                 List<Cortometraje> cortos = cortometrajeService.findByRating(valor);
 
                 if (cortos.isEmpty()) {
-                        throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                                        "No se encontraron cortometrajes con rating >= " + valor);
+                        throw new NotFoundException("No se encontraron cortometrajes con rating >= " + valor);
                 }
 
                 List<CortometrajeResponseDto> response = cortos.stream()
                                 .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
                                 .toList();
 
-                return ResponseEntity.ok(response);
+                return success(response, "Cortometrajes con rating mayor o igual a " + valor);
         }
 
         @GetMapping("/buscar/top5-mejor-valorados")
-        public ResponseEntity<List<CortometrajeResponseDto>> obtenerTop5MejorValorados() {
+        public ResponseEntity<ApiResponse<List<CortometrajeResponseDto>>> obtenerTop5MejorValorados() {
                 List<Cortometraje> top = cortometrajeService.findTopRated();
 
                 List<CortometrajeResponseDto> response = top.stream()
                                 .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
                                 .toList();
 
-                return ResponseEntity.ok(response);
+                return success(response, "Top 5 mejor valorados");
         }
 
         @GetMapping("/buscar/duracion-maxima/{minutos}")
-        public ResponseEntity<List<CortometrajeResponseDto>> buscarPorDuracionMaxima(@PathVariable Integer minutos) {
+        public ResponseEntity<ApiResponse<List<CortometrajeResponseDto>>> buscarPorDuracionMaxima(
+                        @PathVariable Integer minutos) {
                 List<Cortometraje> cortos = cortometrajeService.findByDuracionMenorOIgual(minutos);
 
                 if (cortos.isEmpty()) {
-                        throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                                        "No se encontraron cortometrajes con duración menor o igual a " + minutos
-                                                        + " minutos");
+                        throw new NotFoundException("No se encontraron cortometrajes con duración menor o igual a "
+                                        + minutos + " minutos");
                 }
 
                 List<CortometrajeResponseDto> response = cortos.stream()
                                 .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
                                 .toList();
 
-                return ResponseEntity.ok(response);
+                return success(response, "Cortometrajes con duración menor o igual a " + minutos + " minutos");
         }
 
         @PostMapping
-        public ResponseEntity<CortometrajeResponseDto> create(
+        public ResponseEntity<ApiResponse<CortometrajeResponseDto>> create(
                         @RequestBody @Valid CortometrajeRequestDto cortometrajeDto,
                         Authentication authentication) {
 
                 User autor = userService.findByUsername(authentication.getName())
-                                .orElseThrow(() -> new RuntimeException(
+                                .orElseThrow(() -> new NotFoundException(
                                                 "Usuario no encontrado: " + authentication.getName()));
 
-                Cortometraje cortometraje = modelMapper.map(cortometrajeDto, Cortometraje.class);
-
-                cortometraje.setUser(autor);
-
                 Category categoria = categoryService.findByName(cortometrajeDto.getCategory())
-                                .orElseThrow(() -> new RuntimeException(
+                                .orElseThrow(() -> new NotFoundException(
                                                 "Categoría no encontrada: " + cortometrajeDto.getCategory()));
 
+                Cortometraje cortometraje = modelMapper.map(cortometrajeDto, Cortometraje.class);
+                cortometraje.setUser(autor);
                 cortometraje.setCategory(categoria);
 
-                Cortometraje nuevoCortometraje = cortometrajeService.create(cortometraje);
+                Cortometraje nuevo = cortometrajeService.create(cortometraje);
 
+                // Si es ROLE_USER y no es autor aún, lo marcamos como autor
                 boolean esUsuario = autor.getRoles().stream()
                                 .anyMatch(rol -> rol.getName().equals(Role.RoleType.ROLE_USER));
-
                 if (esUsuario && !autor.getIsAuthor()) {
                         userService.updateAuthorStatus(autor.getId(), true);
                 }
 
-                CortometrajeResponseDto response = modelMapper.map(nuevoCortometraje, CortometrajeResponseDto.class);
+                CortometrajeResponseDto response = modelMapper.map(nuevo, CortometrajeResponseDto.class);
                 response.setAuthor(autor.getUsername());
                 response.setCategory(categoria.getName());
 
-                return ResponseEntity.status(201).body(response);
+                return created(response, "Cortometraje creado correctamente");
         }
 
-        @PutMapping("{id}")
-        public ResponseEntity<CortometrajeResponseDto> update(@PathVariable Long id,
+        @PutMapping("/{id}")
+        public ResponseEntity<ApiResponse<CortometrajeResponseDto>> update(
+                        @PathVariable Long id,
                         @RequestBody @Valid CortometrajeRequestDto cortometrajeDto,
                         Authentication authentication) {
 
-                Cortometraje cortometrajeExistente = cortometrajeService.read(id)
-                                .orElseThrow(() -> new RuntimeException("Cortometraje no encontrado con ID: " + id));
+                Cortometraje existente = cortometrajeService.read(id)
+                                .orElseThrow(() -> new NotFoundException("Cortometraje no encontrado con ID: " + id));
 
                 User autor = userService.findByUsername(authentication.getName())
-                                .orElseThrow(() -> new RuntimeException(
+                                .orElseThrow(() -> new NotFoundException(
                                                 "Usuario no encontrado: " + authentication.getName()));
 
-                boolean esPropietario = cortometrajeExistente.getUser().getId().equals(autor.getId());
+                boolean esPropietario = existente.getUser().getId().equals(autor.getId());
                 boolean esAdmin = autor.getRoles().stream()
                                 .anyMatch(rol -> rol.getName().equals(Role.RoleType.ROLE_ADMIN));
 
                 if (!esPropietario && !esAdmin) {
-                        return ResponseEntity.status(403).body(null);
+                        throw new ForbiddenException("No tienes permisos para actualizar este cortometraje");
                 }
 
-                modelMapper.map(cortometrajeDto, cortometrajeExistente);
+                modelMapper.map(cortometrajeDto, existente);
 
                 Category categoria = categoryService.findByName(cortometrajeDto.getCategory())
-                                .orElseThrow(() -> new RuntimeException(
+                                .orElseThrow(() -> new NotFoundException(
                                                 "Categoría no encontrada: " + cortometrajeDto.getCategory()));
 
-                cortometrajeExistente.setCategory(categoria);
+                existente.setCategory(categoria);
 
-                Cortometraje cortometrajeActualizado = cortometrajeService.update(cortometrajeExistente);
+                Cortometraje actualizado = cortometrajeService.update(existente);
 
-                CortometrajeResponseDto response = modelMapper.map(cortometrajeActualizado,
-                                CortometrajeResponseDto.class);
+                CortometrajeResponseDto response = modelMapper.map(actualizado, CortometrajeResponseDto.class);
                 response.setAuthor(autor.getUsername());
                 response.setCategory(categoria.getName());
 
-                return ResponseEntity.status(200).body(response);
+                return success(response, "Cortometraje actualizado correctamente");
         }
 
-        @DeleteMapping("{id}")
-        public ResponseEntity<Map<String, String>> delete(@PathVariable Long id, Authentication authentication) {
+        @DeleteMapping("/{id}")
+        public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id, Authentication authentication) {
                 User user = userService.findByUsername(authentication.getName())
-                                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+                                .orElseThrow(() -> new NotFoundException(
+                                                "Usuario no encontrado: " + authentication.getName()));
 
                 cortometrajeService.findByIdIfOwnerOrAdmin(id, user)
-                                .orElseThrow(() -> new RuntimeException(
+                                .orElseThrow(() -> new ForbiddenException(
                                                 "No tienes permisos para eliminar este cortometraje"));
 
                 cortometrajeService.delete(id);
-
-                return ResponseEntity.ok(Map.of("message", "Cortometraje eliminado correctamente"));
+                return success(null, "Cortometraje eliminado correctamente");
         }
 
 }

--- a/src/main/java/indimetra/restcontroller/FavoriteRestcontroller.java
+++ b/src/main/java/indimetra/restcontroller/FavoriteRestcontroller.java
@@ -10,129 +10,134 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import indimetra.exception.BadRequestException;
+import indimetra.exception.ForbiddenException;
+import indimetra.exception.NotFoundException;
 import indimetra.modelo.entity.Cortometraje;
 import indimetra.modelo.entity.Favorite;
 import indimetra.modelo.entity.User;
-import indimetra.modelo.service.*;
 import indimetra.modelo.service.Cortometraje.ICortometrajeService;
 import indimetra.modelo.service.Favorite.IFavoriteService;
 import indimetra.modelo.service.Favorite.Model.FavoriteRequestDto;
 import indimetra.modelo.service.Favorite.Model.FavoriteResponseDto;
 import indimetra.modelo.service.User.IUserService;
+import indimetra.restcontroller.base.BaseRestcontroller;
+import indimetra.utils.ApiResponse;
 import jakarta.validation.Valid;
 
 @RestController
 @CrossOrigin(origins = "*")
 @RequestMapping("/favorite")
-public class FavoriteRestcontroller {
+public class FavoriteRestcontroller extends BaseRestcontroller {
 
-    @Autowired
-    private IFavoriteService favoriteService;
+        @Autowired
+        private IFavoriteService favoriteService;
 
-    @Autowired
-    private IUserService userService;
+        @Autowired
+        private IUserService userService;
 
-    @Autowired
-    private ICortometrajeService cortometrajeService;
+        @Autowired
+        private ICortometrajeService cortometrajeService;
 
-    @Autowired
-    private ModelMapper modelMapper;
+        @Autowired
+        private ModelMapper modelMapper;
 
-    //Hay que ver si al solo tener que enviar en el body el cortometrajeId, enviarlo por el path
-    @PostMapping
-    public ResponseEntity<FavoriteResponseDto> addFavorite(
-            @RequestBody @Valid FavoriteRequestDto dto,
-            Authentication authentication) {
+        // Hay que ver si al solo tener que enviar en el body el cortometrajeId,
+        // enviarlo por el path
+        @PostMapping
+        public ResponseEntity<ApiResponse<FavoriteResponseDto>> addFavorite(
+                        @RequestBody @Valid FavoriteRequestDto dto,
+                        Authentication authentication) {
 
-        User user = userService.findByUsername(authentication.getName())
-                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+                User user = userService.findByUsername(authentication.getName())
+                                .orElseThrow(() -> new NotFoundException("Usuario no encontrado"));
 
-        Cortometraje cortometraje = cortometrajeService.read(dto.getCortometrajeId())
-                .orElseThrow(() -> new RuntimeException("Cortometraje no encontrado"));
+                Cortometraje cortometraje = cortometrajeService.read(dto.getCortometrajeId())
+                                .orElseThrow(() -> new NotFoundException("Cortometraje no encontrado"));
 
-        if (favoriteService.isFavoriteOwner(user.getId(), cortometraje.getId())) {
-            throw new RuntimeException("Este cortometraje ya está en tus favoritos");
+                if (favoriteService.isFavoriteOwner(user.getId(), cortometraje.getId())) {
+                        throw new BadRequestException("Este cortometraje ya está en tus favoritos");
+                }
+
+                Favorite favorite = Favorite.builder()
+                                .user(user)
+                                .cortometraje(cortometraje)
+                                .build();
+
+                Favorite saved = favoriteService.create(favorite);
+
+                FavoriteResponseDto response = modelMapper.map(saved, FavoriteResponseDto.class);
+                response.setUsername(user.getUsername());
+                response.setCortometrajeId(cortometraje.getId());
+                response.setCortometrajeTitle(cortometraje.getTitle());
+
+                return created(response, "Favorito añadido correctamente");
         }
 
-        Favorite favorite = Favorite.builder()
-                .user(user)
-                .cortometraje(cortometraje)
-                .build();
+        @GetMapping
+        public ResponseEntity<ApiResponse<List<FavoriteResponseDto>>> getMyFavorites(Authentication authentication) {
+                String username = authentication.getName();
 
-        Favorite saved = favoriteService.create(favorite);
+                List<FavoriteResponseDto> response = favoriteService.findByUsername(username).stream()
+                                .map(fav -> {
+                                        FavoriteResponseDto dto = modelMapper.map(fav, FavoriteResponseDto.class);
+                                        dto.setUsername(fav.getUser().getUsername());
+                                        dto.setCortometrajeId(fav.getCortometraje().getId());
+                                        dto.setCortometrajeTitle(fav.getCortometraje().getTitle());
+                                        return dto;
+                                }).toList();
 
-        FavoriteResponseDto response = modelMapper.map(saved, FavoriteResponseDto.class);
-        response.setUsername(user.getUsername());
-        response.setCortometrajeId(cortometraje.getId());
-        response.setCortometrajeTitle(cortometraje.getTitle());
-
-        return ResponseEntity.status(201).body(response);
-    }
-
-    @GetMapping
-    public ResponseEntity<List<FavoriteResponseDto>> getMyFavorites(Authentication authentication) {
-        String username = authentication.getName();
-        List<Favorite> favorites = favoriteService.findByUsername(username);
-
-        List<FavoriteResponseDto> response = favorites.stream()
-                .map(fav -> {
-                    FavoriteResponseDto dto = modelMapper.map(fav, FavoriteResponseDto.class);
-                    dto.setUsername(fav.getUser().getUsername());
-                    dto.setCortometrajeId(fav.getCortometraje().getId());
-                    dto.setCortometrajeTitle(fav.getCortometraje().getTitle());
-                    return dto;
-                })
-                .collect(Collectors.toList());
-
-        return ResponseEntity.ok(response);
-    }
-
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Map<String, String>> deleteFavorite(@PathVariable Long id, Authentication authentication) {
-        Favorite favorite = favoriteService.read(id)
-                .orElseThrow(() -> new RuntimeException("Favorito no encontrado"));
-
-        User user = userService.findByUsername(authentication.getName())
-                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
-
-        boolean isAdmin = user.getRoles().stream()
-                .anyMatch(r -> r.getName().name().equals("ROLE_ADMIN"));
-
-        boolean isOwner = favorite.getUser().getId().equals(user.getId());
-
-        if (!isAdmin && !isOwner) {
-            return ResponseEntity.status(403).body(Map.of("message", "No tienes permiso para eliminar este favorito"));
+                return success(response, "Favoritos del usuario");
         }
 
-        favoriteService.delete(id);
-        return ResponseEntity.ok(Map.of("message", "Favorito eliminado correctamente"));
-    }
+        @DeleteMapping("/{id}")
+        public ResponseEntity<ApiResponse<Void>> deleteFavorite(@PathVariable Long id, Authentication authentication) {
+                Favorite favorite = favoriteService.read(id)
+                                .orElseThrow(() -> new NotFoundException("Favorito no encontrado"));
 
-    //Solo util si se quiere obtener todos los favoritos para hacer algun modulo de estadistica
-    // @GetMapping("/all")
-    // public ResponseEntity<List<FavoriteResponseDto>> getAllFavorites(Authentication authentication) {
-    //     User user = userService.findByUsername(authentication.getName())
-    //             .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+                User user = userService.findByUsername(authentication.getName())
+                                .orElseThrow(() -> new NotFoundException("Usuario no encontrado"));
 
-    //     boolean isAdmin = user.getRoles().stream()
-    //             .anyMatch(r -> r.getName().name().equals("ROLE_ADMIN"));
+                boolean isAdmin = user.getRoles().stream()
+                                .anyMatch(r -> r.getName().name().equals("ROLE_ADMIN"));
 
-    //     if (!isAdmin) {
-    //         return ResponseEntity.status(403).build();
-    //     }
+                boolean isOwner = favorite.getUser().getId().equals(user.getId());
 
-    //     List<Favorite> allFavorites = favoriteService.findAll();
+                if (!isAdmin && !isOwner) {
+                        throw new ForbiddenException("No tienes permiso para eliminar este favorito");
+                }
 
-    //     List<FavoriteResponseDto> response = allFavorites.stream()
-    //             .map(fav -> {
-    //                 FavoriteResponseDto dto = modelMapper.map(fav, FavoriteResponseDto.class);
-    //                 dto.setUsername(fav.getUser().getUsername());
-    //                 dto.setCortometrajeId(fav.getCortometraje().getId());
-    //                 dto.setCortometrajeTitle(fav.getCortometraje().getTitle());
-    //                 return dto;
-    //             })
-    //             .collect(Collectors.toList());
+                favoriteService.delete(id);
+                return success(null, "Favorito eliminado correctamente");
+        }
 
-    //     return ResponseEntity.ok(response);
-    // }
+        // Solo util si se quiere obtener todos los favoritos para hacer algun modulo de
+        // estadistica
+        // @GetMapping("/all")
+        // public ResponseEntity<List<FavoriteResponseDto>>
+        // getAllFavorites(Authentication authentication) {
+        // User user = userService.findByUsername(authentication.getName())
+        // .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+
+        // boolean isAdmin = user.getRoles().stream()
+        // .anyMatch(r -> r.getName().name().equals("ROLE_ADMIN"));
+
+        // if (!isAdmin) {
+        // return ResponseEntity.status(403).build();
+        // }
+
+        // List<Favorite> allFavorites = favoriteService.findAll();
+
+        // List<FavoriteResponseDto> response = allFavorites.stream()
+        // .map(fav -> {
+        // FavoriteResponseDto dto = modelMapper.map(fav, FavoriteResponseDto.class);
+        // dto.setUsername(fav.getUser().getUsername());
+        // dto.setCortometrajeId(fav.getCortometraje().getId());
+        // dto.setCortometrajeTitle(fav.getCortometraje().getTitle());
+        // return dto;
+        // })
+        // .collect(Collectors.toList());
+
+        // return ResponseEntity.ok(response);
+        // }
 }

--- a/src/main/java/indimetra/restcontroller/RoleRestcontroller.java
+++ b/src/main/java/indimetra/restcontroller/RoleRestcontroller.java
@@ -1,5 +1,7 @@
 package indimetra.restcontroller;
 
-public class RoleRestcontroller {
+import indimetra.restcontroller.base.BaseRestcontroller;
+
+public class RoleRestcontroller extends BaseRestcontroller {
 
 }

--- a/src/main/java/indimetra/restcontroller/UserRestcontroller.java
+++ b/src/main/java/indimetra/restcontroller/UserRestcontroller.java
@@ -1,5 +1,7 @@
 package indimetra.restcontroller;
 
-public class UserRestcontroller {
+import indimetra.restcontroller.base.BaseRestcontroller;
+
+public class UserRestcontroller extends BaseRestcontroller {
 
 }

--- a/src/main/java/indimetra/restcontroller/base/BaseRestcontroller.java
+++ b/src/main/java/indimetra/restcontroller/base/BaseRestcontroller.java
@@ -1,0 +1,32 @@
+package indimetra.restcontroller.base;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import indimetra.utils.ApiResponse;
+
+public abstract class BaseRestcontroller {
+    protected String getUsername() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return auth != null ? auth.getName() : "Anónimo";
+    }
+
+    protected boolean isAdmin() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return auth != null && auth.getAuthorities().stream()
+                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN"));
+    }
+
+    protected <T> ResponseEntity<ApiResponse<T>> success(T data, String message) {
+        return ResponseEntity.ok(new ApiResponse<>(data, message));
+    }
+
+    protected <T> ResponseEntity<ApiResponse<T>> created(T data, String message) {
+        return ResponseEntity.status(201).body(new ApiResponse<>(data, message));
+    }
+
+    protected <T> ResponseEntity<ApiResponse<T>> failure(String message) {
+        return ResponseEntity.badRequest().body(new ApiResponse<>(message));
+    }
+}

--- a/src/main/java/indimetra/utils/ApiResponse.java
+++ b/src/main/java/indimetra/utils/ApiResponse.java
@@ -1,0 +1,35 @@
+package indimetra.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private boolean success;
+    private String message;
+    private T data;
+
+    // Constructor para éxito con datos, por defecto
+    public ApiResponse(T data) {
+        this.success = true;
+        this.message = "Operación exitosa";
+        this.data = data;
+    }
+
+    // Constructor para éxito con datos + mensaje personalizado
+    public ApiResponse(T data, String message) {
+        this.success = true;
+        this.message = message;
+        this.data = data;
+    }
+
+    // Constructor para fallo con mensaje personalizado
+    public ApiResponse(String message) {
+        this.success = false;
+        this.message = message;
+        this.data = null;
+    }
+}


### PR DESCRIPTION
### Cambios realizados
- Se reemplazó la herencia de `GenericoCRUDServiceImplMy8` por `GenericDtoServiceImpl` en `CategoryServiceImplMy8`.
- Se eliminó el uso directo de `ModelMapper` en el controlador `CategoryRestcontroller`.
- Se delegó toda la lógica de creación, actualización y lectura al servicio.
- Se implementaron métodos requeridos por la clase genérica: `getEntityClass()`, `getRequestDtoClass()`, `getResponseDtoClass()` y `setEntityId()`.

### Motivo
Este refactor permite:
- Centralizar la lógica común en una clase base.
- Eliminar la duplicación de código entre servicios.
- Mejorar la legibilidad y mantenibilidad del código.
- Trabajar directamente con DTOs en toda la capa de servicio.

### Impacto
Este cambio solo afecta al módulo `Category` y no debería impactar a otros servicios. Ya está preparado para extender esta arquitectura al resto de entidades como `Cortometraje`, `Review`, `Favorite`, etc.
