### PR TITLE
Refactoriza servicios y controladores: lógica movida al servicio y li…

### DIFF
--- a/src/main/java/indimetra/modelo/service/Base/GenericDtoServiceImpl.java
+++ b/src/main/java/indimetra/modelo/service/Base/GenericDtoServiceImpl.java
@@ -1,6 +1,7 @@
 package indimetra.modelo.service.Base;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +65,11 @@ public abstract class GenericDtoServiceImpl<TEntity, TRequestDto, TResponseDto, 
         }
 
         getRepository().deleteById(id);
+    }
+
+    @Override
+    public Optional<TEntity> read(ID id) {
+        return getRepository().findById(id);
     }
 
     protected TEntity readEntityById(ID id) {

--- a/src/main/java/indimetra/modelo/service/Base/IGenericDtoService.java
+++ b/src/main/java/indimetra/modelo/service/Base/IGenericDtoService.java
@@ -1,6 +1,7 @@
 package indimetra.modelo.service.Base;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface IGenericDtoService<
     TEntity, 
@@ -17,5 +18,7 @@ public interface IGenericDtoService<
     TResponseDto update(ID id, TRequestDto dto);
 
     void delete(ID id);
+
+    Optional<TEntity> read(ID id);
 }
 

--- a/src/main/java/indimetra/modelo/service/Favorite/FavoriteServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/Favorite/FavoriteServiceImplMy8.java
@@ -1,24 +1,66 @@
 package indimetra.modelo.service.Favorite;
 
+import java.util.Date;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import indimetra.exception.BadRequestException;
+import indimetra.exception.ForbiddenException;
+import indimetra.exception.NotFoundException;
+import indimetra.modelo.entity.Cortometraje;
 import indimetra.modelo.entity.Favorite;
+import indimetra.modelo.entity.User;
 import indimetra.modelo.repository.IFavoriteRepository;
-import indimetra.modelo.service.Base.GenericoCRUDServiceImplMy8;
+import indimetra.modelo.service.Base.GenericDtoServiceImpl;
+import indimetra.modelo.service.Cortometraje.ICortometrajeService;
+import indimetra.modelo.service.Favorite.Model.FavoriteRequestDto;
+import indimetra.modelo.service.Favorite.Model.FavoriteResponseDto;
+import indimetra.modelo.service.User.IUserService;
 
 @Service
-public class FavoriteServiceImplMy8 extends GenericoCRUDServiceImplMy8<Favorite, Long> implements IFavoriteService {
+public class FavoriteServiceImplMy8
+        extends GenericDtoServiceImpl<Favorite, FavoriteRequestDto, FavoriteResponseDto, Long>
+        implements IFavoriteService {
 
     @Autowired
     private IFavoriteRepository favoriteRepository;
 
+    @Autowired
+    private IUserService userService;
+
+    @Autowired
+    private ICortometrajeService cortometrajeService;
+
     @Override
     protected IFavoriteRepository getRepository() {
         return favoriteRepository;
+    }
+
+    @Override
+    protected Class<Favorite> getEntityClass() {
+        return Favorite.class;
+    }
+
+    @Override
+    protected Class<FavoriteRequestDto> getRequestDtoClass() {
+        return FavoriteRequestDto.class;
+    }
+
+    @Override
+    protected Class<FavoriteResponseDto> getResponseDtoClass() {
+        return FavoriteResponseDto.class;
+    }
+
+    @Override
+    protected void setEntityId(Favorite entity, Long id) {
+        entity.setId(id);
+    }
+
+    @Override
+    public boolean isFavoriteOwner(Long userId, Long cortometrajeId) {
+        return favoriteRepository.findByUserIdAndCortometrajeId(userId, cortometrajeId).isPresent();
     }
 
     @Override
@@ -38,11 +80,64 @@ public class FavoriteServiceImplMy8 extends GenericoCRUDServiceImplMy8<Favorite,
     }
 
     @Override
-    public boolean isFavoriteOwner(Long userId, Long cortometrajeId) {
-        if (userId == null || cortometrajeId == null) {
-            throw new BadRequestException("El ID del usuario y del cortometraje no pueden ser nulos");
+    public FavoriteResponseDto addFavorite(FavoriteRequestDto dto, String username) {
+        User user = userService.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException("Usuario no encontrado"));
+
+        Cortometraje cortometraje = cortometrajeService.read(dto.getCortometrajeId())
+                .orElseThrow(() -> new NotFoundException("Cortometraje no encontrado"));
+
+        if (isFavoriteOwner(user.getId(), cortometraje.getId())) {
+            throw new BadRequestException("Este cortometraje ya está en tus favoritos");
         }
 
-        return favoriteRepository.findByUserIdAndCortometrajeId(userId, cortometrajeId).isPresent();
+        Favorite favorite = Favorite.builder()
+                .user(user)
+                .cortometraje(cortometraje)
+                .addedAt(new Date())
+                .build();
+
+        Favorite saved = favoriteRepository.save(favorite);
+
+        return FavoriteResponseDto.builder()
+                .id(saved.getId())
+                .username(user.getUsername())
+                .cortometrajeId(cortometraje.getId())
+                .cortometrajeTitle(cortometraje.getTitle())
+                .addedAt(saved.getAddedAt())
+                .build();
     }
+
+    @Override
+    public List<FavoriteResponseDto> findAllByUsername(String username) {
+        return findByUsername(username).stream()
+                .map(fav -> FavoriteResponseDto.builder()
+                        .id(fav.getId())
+                        .username(fav.getUser().getUsername())
+                        .cortometrajeId(fav.getCortometraje().getId())
+                        .cortometrajeTitle(fav.getCortometraje().getTitle())
+                        .addedAt(fav.getAddedAt())
+                        .build())
+                .toList();
+    }
+
+    @Override
+    public void deleteFavoriteIfOwnerOrAdmin(Long id, String username) {
+        Favorite favorite = favoriteRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Favorito no encontrado"));
+
+        User user = userService.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException("Usuario no encontrado"));
+
+        boolean isAdmin = user.getRoles().stream()
+                .anyMatch(r -> r.getName().name().equals("ROLE_ADMIN"));
+        boolean isOwner = favorite.getUser().getId().equals(user.getId());
+
+        if (!isAdmin && !isOwner) {
+            throw new ForbiddenException("No tienes permiso para eliminar este favorito");
+        }
+
+        favoriteRepository.delete(favorite);
+    }
+
 }

--- a/src/main/java/indimetra/modelo/service/Favorite/IFavoriteService.java
+++ b/src/main/java/indimetra/modelo/service/Favorite/IFavoriteService.java
@@ -3,16 +3,21 @@ package indimetra.modelo.service.Favorite;
 import java.util.List;
 
 import indimetra.modelo.entity.Favorite;
-import indimetra.modelo.service.Base.IGenericoCRUD;
+import indimetra.modelo.service.Base.IGenericDtoService;
+import indimetra.modelo.service.Favorite.Model.FavoriteRequestDto;
+import indimetra.modelo.service.Favorite.Model.FavoriteResponseDto;
 
-public interface IFavoriteService extends IGenericoCRUD<Favorite, Long> {
+public interface IFavoriteService extends IGenericDtoService<Favorite, FavoriteRequestDto, FavoriteResponseDto, Long> {
 
     List<Favorite> findByUserId(Long userId);
-    
-    List<Favorite> findByUsername(String username);
 
-    // void deleteByUserIdAndSeriesId(Long userId, Long seriesId);
+    List<Favorite> findByUsername(String username);
 
     boolean isFavoriteOwner(Long userId, Long cortometrajeId);
 
+    FavoriteResponseDto addFavorite(FavoriteRequestDto dto, String username);
+
+    List<FavoriteResponseDto> findAllByUsername(String username);
+
+    void deleteFavoriteIfOwnerOrAdmin(Long id, String username);
 }

--- a/src/main/java/indimetra/restcontroller/FavoriteRestcontroller.java
+++ b/src/main/java/indimetra/restcontroller/FavoriteRestcontroller.java
@@ -1,26 +1,14 @@
 package indimetra.restcontroller;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
-import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
-import indimetra.exception.BadRequestException;
-import indimetra.exception.ForbiddenException;
-import indimetra.exception.NotFoundException;
-import indimetra.modelo.entity.Cortometraje;
-import indimetra.modelo.entity.Favorite;
-import indimetra.modelo.entity.User;
-import indimetra.modelo.service.Cortometraje.ICortometrajeService;
 import indimetra.modelo.service.Favorite.IFavoriteService;
 import indimetra.modelo.service.Favorite.Model.FavoriteRequestDto;
 import indimetra.modelo.service.Favorite.Model.FavoriteResponseDto;
-import indimetra.modelo.service.User.IUserService;
 import indimetra.restcontroller.base.BaseRestcontroller;
 import indimetra.utils.ApiResponse;
 import jakarta.validation.Valid;
@@ -33,81 +21,25 @@ public class FavoriteRestcontroller extends BaseRestcontroller {
         @Autowired
         private IFavoriteService favoriteService;
 
-        @Autowired
-        private IUserService userService;
-
-        @Autowired
-        private ICortometrajeService cortometrajeService;
-
-        @Autowired
-        private ModelMapper modelMapper;
-
         // Hay que ver si al solo tener que enviar en el body el cortometrajeId,
         // enviarlo por el path
-        // @PostMapping
-        // public ResponseEntity<ApiResponse<FavoriteResponseDto>> addFavorite(
-        //                 @RequestBody @Valid FavoriteRequestDto dto,
-        //                 Authentication authentication) {
+        @PostMapping
+        public ResponseEntity<ApiResponse<FavoriteResponseDto>> addFavorite(
+                        @RequestBody @Valid FavoriteRequestDto dto) {
 
-        //         User user = userService.findByUsername(authentication.getName())
-        //                         .orElseThrow(() -> new NotFoundException("Usuario no encontrado"));
-
-        //         Cortometraje cortometraje = cortometrajeService.read(dto.getCortometrajeId())
-        //                         .orElseThrow(() -> new NotFoundException("Cortometraje no encontrado"));
-
-        //         if (favoriteService.isFavoriteOwner(user.getId(), cortometraje.getId())) {
-        //                 throw new BadRequestException("Este cortometraje ya está en tus favoritos");
-        //         }
-
-        //         Favorite favorite = Favorite.builder()
-        //                         .user(user)
-        //                         .cortometraje(cortometraje)
-        //                         .build();
-
-        //         Favorite saved = favoriteService.create(favorite);
-
-        //         FavoriteResponseDto response = modelMapper.map(saved, FavoriteResponseDto.class);
-        //         response.setUsername(user.getUsername());
-        //         response.setCortometrajeId(cortometraje.getId());
-        //         response.setCortometrajeTitle(cortometraje.getTitle());
-
-        //         return created(response, "Favorito añadido correctamente");
-        // }
+                FavoriteResponseDto response = favoriteService.addFavorite(dto, getUsername());
+                return created(response, "Favorito añadido correctamente");
+        }
 
         @GetMapping
-        public ResponseEntity<ApiResponse<List<FavoriteResponseDto>>> getMyFavorites(Authentication authentication) {
-                String username = authentication.getName();
-
-                List<FavoriteResponseDto> response = favoriteService.findByUsername(username).stream()
-                                .map(fav -> {
-                                        FavoriteResponseDto dto = modelMapper.map(fav, FavoriteResponseDto.class);
-                                        dto.setUsername(fav.getUser().getUsername());
-                                        dto.setCortometrajeId(fav.getCortometraje().getId());
-                                        dto.setCortometrajeTitle(fav.getCortometraje().getTitle());
-                                        return dto;
-                                }).toList();
-
+        public ResponseEntity<ApiResponse<List<FavoriteResponseDto>>> getMyFavorites() {
+                List<FavoriteResponseDto> response = favoriteService.findAllByUsername(getUsername());
                 return success(response, "Favoritos del usuario");
         }
 
         @DeleteMapping("/{id}")
-        public ResponseEntity<ApiResponse<Void>> deleteFavorite(@PathVariable Long id, Authentication authentication) {
-                Favorite favorite = favoriteService.read(id)
-                                .orElseThrow(() -> new NotFoundException("Favorito no encontrado"));
-
-                User user = userService.findByUsername(authentication.getName())
-                                .orElseThrow(() -> new NotFoundException("Usuario no encontrado"));
-
-                boolean isAdmin = user.getRoles().stream()
-                                .anyMatch(r -> r.getName().name().equals("ROLE_ADMIN"));
-
-                boolean isOwner = favorite.getUser().getId().equals(user.getId());
-
-                if (!isAdmin && !isOwner) {
-                        throw new ForbiddenException("No tienes permiso para eliminar este favorito");
-                }
-
-                favoriteService.delete(id);
+        public ResponseEntity<ApiResponse<Void>> deleteFavorite(@PathVariable Long id) {
+                favoriteService.deleteFavoriteIfOwnerOrAdmin(id, getUsername());
                 return success(null, "Favorito eliminado correctamente");
         }
 


### PR DESCRIPTION
Este commit centraliza la lógica de negocio en las capas de servicio para los módulos de Cortometraje y Favorito, eliminando responsabilidades innecesarias de los controladores.

Cambios principales:
- Refactor de CortometrajeRestcontroller y FavoriteRestcontroller
- Se delega toda la lógica de validación y autorización a los servicios
- Se implementa el método read(ID) en GenericDtoServiceImpl
- Se crean métodos personalizados en FavoriteService para añadir, listar y eliminar favoritos
- Se mejora la coherencia en el uso de DTOs y entidades en los servicios

Este refactor mejora la cohesión de cada capa, la legibilidad del código y la capacidad de reutilización de la lógica.
