### PR TITLE
� Fix: Filtrado por isActive/isDeleted en todos los métodos de cortom…

### DIFF
--- a/src/main/java/indimetra/auth/SpringSecurityConfig.java
+++ b/src/main/java/indimetra/auth/SpringSecurityConfig.java
@@ -75,8 +75,9 @@ public class SpringSecurityConfig {
                         // Rutas ROLE_USER
                         .requestMatchers(HttpMethod.GET, "/cortometraje/buscar/mis-cortometrajes").hasAuthority("ROLE_USER")
                         .requestMatchers(HttpMethod.POST, "/cortometraje").hasAuthority("ROLE_USER")
-                        .requestMatchers(HttpMethod.PUT, "/cortometraje/{id}").hasAuthority("ROLE_USER")
-                        .requestMatchers(HttpMethod.DELETE, "/cortometraje/{id}").hasAuthority("ROLE_USER")
+                        // Rutas ROLE_ADMIN / ROLE_USER(owner)
+                        .requestMatchers(HttpMethod.DELETE, "/cortometraje/{id}").hasAnyAuthority("ROLE_USER", "ROLE_ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/cortometraje/{id}").hasAnyAuthority("ROLE_USER", "ROLE_ADMIN")
 
                 // CATEGORY
                         // Rutas públicas

--- a/src/main/java/indimetra/modelo/repository/ICortometrajeRepository.java
+++ b/src/main/java/indimetra/modelo/repository/ICortometrajeRepository.java
@@ -44,7 +44,7 @@ public interface ICortometrajeRepository extends JpaRepository<Cortometraje, Lon
     boolean existsByTitleAndIdNot(String title, Long id);
 
     // Filtrados por isActive e isDeleted
-    
+
     List<Cortometraje> findByIsActiveTrueAndIsDeletedFalse();
 
     List<Cortometraje> findByUserAndIsActiveTrueAndIsDeletedFalse(User user);
@@ -54,8 +54,25 @@ public interface ICortometrajeRepository extends JpaRepository<Cortometraje, Lon
     List<Cortometraje> findByCategoryNameIgnoreCaseAndIsActiveTrueAndIsDeletedFalse(String categoryName);
 
     Page<Cortometraje> findByIsActiveTrueAndIsDeletedFalse(Pageable pageable);
-    
+
     boolean existsByUserIdAndIsDeletedFalse(Long userId);
 
+    @Query("""
+                SELECT c FROM Cortometraje c
+                WHERE c.isActive = true
+                AND c.isDeleted = false
+                AND c.user.isActive = true
+                AND c.user.isDeleted = false
+            """)
+    List<Cortometraje> findAllVisible();
+
+    @Query("""
+                SELECT c FROM Cortometraje c
+                WHERE c.isActive = true
+                AND c.isDeleted = false
+                AND c.user.isActive = true
+                AND c.user.isDeleted = false
+            """)
+    Page<Cortometraje> findAllVisible(Pageable pageable);
 
 }


### PR DESCRIPTION
✅ Se han adaptado todos los métodos públicos del servicio Cortometraje para:
- Mostrar solo cortometrajes activos y no eliminados
- Verificar también que el autor esté activo
- Evitar acceso directo a cortometrajes inactivos desde sus endpoints

Esto asegura coherencia visual y lógica en toda la app.
