### PR TITLE
Feature/soft delete review favorite

### DIFF
--- a/src/main/java/indimetra/auth/SpringSecurityConfig.java
+++ b/src/main/java/indimetra/auth/SpringSecurityConfig.java
@@ -70,6 +70,8 @@ public class SpringSecurityConfig {
                                 "/cortometraje/buscar/top5-mejor-valorados",
                                 "/cortometraje/buscar/duracion-maxima/{minutos}",
                                 "/cortometraje/paginated",
+                                "/cortometraje/buscar/autor/{username}",
+                                "/cortometraje/buscar/idioma/{language}",
                                 "/cortometraje/{id}")
                         .permitAll()
                         // Rutas ROLE_USER
@@ -92,17 +94,21 @@ public class SpringSecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/category/{id}").hasAuthority("ROLE_ADMIN")
 
                 // REVIEW
+                        // Rutas públicas
                         .requestMatchers(HttpMethod.GET,
                                 "/review",
+                                "/review/buscar/por-cortometraje/{cortometrajeId}",
+                                "/review/buscar/por-usuario/{username}",
                                 "/review/{id}")
-                        .authenticated()
+                        .permitAll()
                         .requestMatchers(HttpMethod.POST, "/review").hasAuthority("ROLE_USER")
 
                         // ROLE_USER(owner) / ROLE_ADMIN
-                        .requestMatchers(HttpMethod.PUT, "/review/{id}").hasAnyAuthority("ROLE_USER", "ROLE_ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/review/{id}").hasAnyAuthority("ROLE_USER", "ROLE_ADMIN")
+                        
                         //USER_OWNER
                         .requestMatchers(HttpMethod.GET, "/review/mis-reviews").hasAnyAuthority("ROLE_USER")
+                        .requestMatchers(HttpMethod.PUT, "/review/{id}").hasAuthority("ROLE_USER")
 
                 // FAVORITE
                         // Rutas USER

--- a/src/main/java/indimetra/modelo/repository/ICortometrajeRepository.java
+++ b/src/main/java/indimetra/modelo/repository/ICortometrajeRepository.java
@@ -75,4 +75,6 @@ public interface ICortometrajeRepository extends JpaRepository<Cortometraje, Lon
             """)
     Page<Cortometraje> findAllVisible(Pageable pageable);
 
+    List<Cortometraje> findByLanguageIgnoreCaseAndIsActiveTrueAndIsDeletedFalse(String language);
+
 }

--- a/src/main/java/indimetra/modelo/repository/ICortometrajeRepository.java
+++ b/src/main/java/indimetra/modelo/repository/ICortometrajeRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import indimetra.modelo.entity.Category;
 import indimetra.modelo.entity.Cortometraje;
 import indimetra.modelo.entity.User;
 
@@ -42,6 +43,8 @@ public interface ICortometrajeRepository extends JpaRepository<Cortometraje, Lon
     boolean existsByTitle(String title);
 
     boolean existsByTitleAndIdNot(String title, Long id);
+
+    boolean existsByCategory(Category category);
 
     // Filtrados por isActive e isDeleted
 

--- a/src/main/java/indimetra/modelo/repository/IReviewRepository.java
+++ b/src/main/java/indimetra/modelo/repository/IReviewRepository.java
@@ -19,9 +19,8 @@ public interface IReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findByUserIdAndIsDeletedFalse(Long userId);
 
-    List<Review> findByIsActiveTrueAndIsDeletedFalse();
-
     // Filtrados por isActive e isDeleted
+    List<Review> findByIsActiveTrueAndIsDeletedFalse();
 
     List<Review> findByUserIdAndIsActiveTrueAndIsDeletedFalse(Long userId);
 
@@ -31,5 +30,8 @@ public interface IReviewRepository extends JpaRepository<Review, Long> {
 
     boolean existsByUserIdAndCortometrajeIdAndIsDeletedFalse(Long userId, Long cortometrajeId);
 
+    List<Review> findByIsDeletedFalse();
+
+    List<Review> findByCortometrajeIdAndIsDeletedFalse(Long cortometrajeId);
 
 }

--- a/src/main/java/indimetra/modelo/repository/IReviewRepository.java
+++ b/src/main/java/indimetra/modelo/repository/IReviewRepository.java
@@ -11,8 +11,7 @@ import indimetra.modelo.entity.Review;
 
 public interface IReviewRepository extends JpaRepository<Review, Long> {
 
-    // Hay que hacer pruebas para ver si funciona
-    @Query("SELECT COALESCE(AVG(r.rating), 0) FROM Review r WHERE r.cortometraje.id = :cortometrajeId")
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.cortometraje.id = :cortometrajeId AND r.isActive = true AND r.isDeleted = false")
     BigDecimal calcularPromedioRating(@Param("cortometrajeId") Long cortometrajeId);
 
     boolean existsByUserIdAndCortometrajeId(Long userId, Long cortometrajeId);

--- a/src/main/java/indimetra/modelo/service/Auth/AuthServiceImpl.java
+++ b/src/main/java/indimetra/modelo/service/Auth/AuthServiceImpl.java
@@ -93,6 +93,14 @@ public class AuthServiceImpl implements IAuthService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new NotFoundException("Usuario no encontrado: " + username));
 
+        if (!user.getIsActive()) {
+            throw new BadRequestException("Tu cuenta está deshabilitada.");
+        }
+
+        if (user.getIsDeleted()) {
+            throw new BadRequestException("Tu cuenta ha sido eliminada.");
+        }
+
         return modelMapper.map(user, UserResponseDto.class);
     }
 

--- a/src/main/java/indimetra/modelo/service/Category/CategoryServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/Category/CategoryServiceImplMy8.java
@@ -6,8 +6,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import indimetra.exception.BadRequestException;
+import indimetra.exception.NotFoundException;
 import indimetra.modelo.entity.Category;
 import indimetra.modelo.repository.ICategoryRepository;
+import indimetra.modelo.repository.ICortometrajeRepository;
 import indimetra.modelo.service.Base.GenericDtoServiceImpl;
 import indimetra.modelo.service.Category.Model.CategoryRequestDto;
 import indimetra.modelo.service.Category.Model.CategoryResponseDto;
@@ -18,6 +20,9 @@ public class CategoryServiceImplMy8 extends
 
     @Autowired
     private ICategoryRepository categoryRepository;
+
+    @Autowired
+    private ICortometrajeRepository cortometrajeRepository;
 
     @Override
     protected ICategoryRepository getRepository() {
@@ -39,7 +44,8 @@ public class CategoryServiceImplMy8 extends
         return CategoryResponseDto.class;
     }
 
-    // Usa en la lógica de actualización (update) para asignar manualmente el ID al entity, ya que los DTOs no lo tienen
+    // Usa en la lógica de actualización (update) para asignar manualmente el ID al
+    // entity, ya que los DTOs no lo tienen
     @Override
     protected void setEntityId(Category entity, Long id) {
         entity.setId(id);
@@ -52,4 +58,19 @@ public class CategoryServiceImplMy8 extends
         }
         return categoryRepository.findByName(name);
     }
+
+    @Override
+    public void delete(Long id) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Categoría no encontrada con ID: " + id));
+
+        boolean tieneCortosAsociados = cortometrajeRepository.existsByCategory(category);
+
+        if (tieneCortosAsociados) {
+            throw new BadRequestException("No se puede eliminar la categoría. Hay cortometrajes asociados.");
+        }
+
+        categoryRepository.deleteById(id);
+    }
+
 }

--- a/src/main/java/indimetra/modelo/service/Cortometraje/CortometrajeServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/Cortometraje/CortometrajeServiceImplMy8.java
@@ -331,4 +331,38 @@ public class CortometrajeServiceImplMy8
                 .toList();
     }
 
+    @Override
+    public List<CortometrajeResponseDto> findByAuthor(String username) {
+        User user = userService.findByUsername(username)
+                .orElseThrow(() -> new NotFoundException("Usuario no encontrado: " + username));
+
+        List<Cortometraje> lista = cortometrajeRepository.findByUserAndIsActiveTrueAndIsDeletedFalse(user);
+
+        if (lista.isEmpty()) {
+            throw new NotFoundException("Este autor no tiene cortometrajes disponibles.");
+        }
+
+        return lista.stream()
+                .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
+                .toList();
+    }
+
+    @Override
+    public List<CortometrajeResponseDto> findByLanguage(String language) {
+        if (language == null || language.trim().isEmpty()) {
+            throw new BadRequestException("El idioma no puede estar vacío.");
+        }
+
+        List<Cortometraje> lista = cortometrajeRepository
+                .findByLanguageIgnoreCaseAndIsActiveTrueAndIsDeletedFalse(language);
+
+        if (lista.isEmpty()) {
+            throw new NotFoundException("No se encontraron cortometrajes en el idioma: " + language);
+        }
+
+        return lista.stream()
+                .map(c -> modelMapper.map(c, CortometrajeResponseDto.class))
+                .toList();
+    }
+
 }

--- a/src/main/java/indimetra/modelo/service/Cortometraje/ICortometrajeService.java
+++ b/src/main/java/indimetra/modelo/service/Cortometraje/ICortometrajeService.java
@@ -45,4 +45,7 @@ public interface ICortometrajeService
 
     List<CortometrajeResponseDto> findByUsername(String username);
 
+    List<CortometrajeResponseDto> findByAuthor(String username);
+
+    List<CortometrajeResponseDto> findByLanguage(String language);
 }

--- a/src/main/java/indimetra/modelo/service/Favorite/IFavoriteService.java
+++ b/src/main/java/indimetra/modelo/service/Favorite/IFavoriteService.java
@@ -15,8 +15,8 @@ public interface IFavoriteService extends IGenericDtoService<Favorite, FavoriteR
 
     boolean isFavoriteOwner(Long userId, Long cortometrajeId);
 
-    FavoriteResponseDto addFavorite(FavoriteRequestDto dto, String username);
-
+    FavoriteResponseDto addOrRestoreFavorite(FavoriteRequestDto dto, String username);
+    
     List<FavoriteResponseDto> findAllByUsername(String username);
 
     void deleteFavoriteIfOwnerOrAdmin(Long id, String username);

--- a/src/main/java/indimetra/modelo/service/Review/IReviewService.java
+++ b/src/main/java/indimetra/modelo/service/Review/IReviewService.java
@@ -29,4 +29,5 @@ public interface IReviewService extends IGenericDtoService<Review, ReviewRequest
 
     List<ReviewResponseDto> findAllByUsername(String username);
 
+    List<ReviewResponseDto> findAllByCortometrajeId(Long cortometrajeId);
 }

--- a/src/main/java/indimetra/modelo/service/Review/ReviewServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/Review/ReviewServiceImplMy8.java
@@ -223,8 +223,34 @@ public class ReviewServiceImplMy8
                 .orElseThrow(() -> new NotFoundException("Usuario no encontrado"));
 
         return reviewRepository.findByUserIdAndIsDeletedFalse(user.getId()).stream()
+                .filter(r -> r.getCortometraje() != null &&
+                        r.getCortometraje().getIsActive() &&
+                        !r.getCortometraje().getIsDeleted() &&
+                        r.getCortometraje().getUser().getIsActive())
                 .map(review -> modelMapper.map(review, ReviewResponseDto.class))
                 .toList();
+    }
+
+    @Override
+    public ReviewResponseDto findById(Long id) {
+        Review review = readEntityById(id);
+
+        if (review.getIsDeleted()
+                || review.getCortometraje() == null
+                || review.getCortometraje().getIsDeleted()
+                || !review.getCortometraje().getIsActive()
+                || !review.getCortometraje().getUser().getIsActive()) {
+            throw new NotFoundException("Reseña no disponible o el cortometraje está desactivado");
+        }
+
+        return ReviewResponseDto.builder()
+                .id(review.getId())
+                .rating(review.getRating())
+                .comment(review.getComment())
+                .username(review.getUser().getUsername())
+                .cortometrajeId(review.getCortometraje().getId())
+                .cortometrajeTitle(review.getCortometraje().getTitle())
+                .build();
     }
 
 }

--- a/src/main/java/indimetra/modelo/service/Review/ReviewServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/Review/ReviewServiceImplMy8.java
@@ -253,4 +253,26 @@ public class ReviewServiceImplMy8
                 .build();
     }
 
+    @Override
+    public List<ReviewResponseDto> findAll() {
+        return reviewRepository.findByIsDeletedFalse().stream()
+                .filter(r -> r.getCortometraje() != null &&
+                        r.getCortometraje().getIsActive() &&
+                        !r.getCortometraje().getIsDeleted() &&
+                        r.getCortometraje().getUser().getIsActive())
+                .map(r -> modelMapper.map(r, ReviewResponseDto.class))
+                .toList();
+    }
+
+    @Override
+    public List<ReviewResponseDto> findAllByCortometrajeId(Long cortometrajeId) {
+        return reviewRepository.findByCortometrajeIdAndIsDeletedFalse(cortometrajeId).stream()
+                .filter(r -> r.getCortometraje() != null &&
+                        r.getCortometraje().getIsActive() &&
+                        !r.getCortometraje().getIsDeleted() &&
+                        r.getCortometraje().getUser().getIsActive())
+                .map(review -> modelMapper.map(review, ReviewResponseDto.class))
+                .toList();
+    }
+
 }

--- a/src/main/java/indimetra/modelo/service/Review/ReviewServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/Review/ReviewServiceImplMy8.java
@@ -213,7 +213,10 @@ public class ReviewServiceImplMy8
             throw new ForbiddenException("No tienes permisos para eliminar esta reseña");
         }
 
-        reviewRepository.deleteById(id);
+        review.setIsDeleted(true);
+        review.setIsActive(false);
+        reviewRepository.save(review);
+
         actualizarRatingCortometraje(review.getCortometraje().getId());
     }
 

--- a/src/main/java/indimetra/restcontroller/AuthRestcontroller.java
+++ b/src/main/java/indimetra/restcontroller/AuthRestcontroller.java
@@ -52,6 +52,7 @@ public class AuthRestcontroller extends BaseRestcontroller {
         return created(newUser, "Usuario registrado correctamente");
     }
 
+    //FALTA METER REDES SOCIALES EN EL DTO DE SALIDA
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserResponseDto>> getAuthenticatedUser() {

--- a/src/main/java/indimetra/restcontroller/CortometrajeRestcontroller.java
+++ b/src/main/java/indimetra/restcontroller/CortometrajeRestcontroller.java
@@ -54,6 +54,20 @@ public class CortometrajeRestcontroller extends BaseRestcontroller {
                 return success(response, "Tus cortometrajes");
         }
 
+        @GetMapping("/buscar/autor/{username}")
+        public ResponseEntity<ApiResponse<List<CortometrajeResponseDto>>> buscarPorAutor(
+                        @PathVariable String username) {
+                List<CortometrajeResponseDto> response = cortometrajeService.findByAuthor(username);
+                return success(response, "Cortometrajes del autor: " + username);
+        }
+
+        @GetMapping("/buscar/idioma/{language}")
+        public ResponseEntity<ApiResponse<List<CortometrajeResponseDto>>> buscarPorIdioma(
+                        @PathVariable String language) {
+                List<CortometrajeResponseDto> response = cortometrajeService.findByLanguage(language);
+                return success(response, "Cortometrajes en idioma: " + language);
+        }
+
         @GetMapping("/buscar/{title}")
         public ResponseEntity<ApiResponse<List<CortometrajeResponseDto>>> buscarPorTitulo(@PathVariable String title) {
                 List<CortometrajeResponseDto> response = cortometrajeService.findByTitleContainingIgnoreCase(title);
@@ -80,6 +94,7 @@ public class CortometrajeRestcontroller extends BaseRestcontroller {
                 return success(response, "Cortometrajes con rating >= " + valor);
         }
 
+        // 4
         @GetMapping("/buscar/top5-mejor-valorados")
         public ResponseEntity<ApiResponse<List<CortometrajeResponseDto>>> obtenerTop5MejorValorados() {
                 List<CortometrajeResponseDto> response = cortometrajeService.findTopRated();

--- a/src/main/java/indimetra/restcontroller/FavoriteRestcontroller.java
+++ b/src/main/java/indimetra/restcontroller/FavoriteRestcontroller.java
@@ -29,7 +29,7 @@ public class FavoriteRestcontroller extends BaseRestcontroller {
         public ResponseEntity<ApiResponse<FavoriteResponseDto>> addFavorite(
                         @RequestBody @Valid FavoriteRequestDto dto) {
 
-                FavoriteResponseDto response = favoriteService.addFavorite(dto, getUsername());
+                FavoriteResponseDto response = favoriteService.addOrRestoreFavorite(dto, getUsername());
                 return created(response, "Favorito añadido correctamente");
         }
 

--- a/src/main/java/indimetra/restcontroller/ReviewRestcontroller.java
+++ b/src/main/java/indimetra/restcontroller/ReviewRestcontroller.java
@@ -12,8 +12,11 @@ import indimetra.modelo.service.Review.Model.ReviewRequestDto;
 import indimetra.modelo.service.Review.Model.ReviewResponseDto;
 import indimetra.restcontroller.base.BaseRestcontroller;
 import indimetra.utils.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
+@Tag(name = "Review Controller", description = "Gestión de reseñas de cortometrajes")
 @RestController
 @CrossOrigin(origins = "*")
 @RequestMapping("/review")
@@ -22,13 +25,36 @@ public class ReviewRestcontroller extends BaseRestcontroller {
         @Autowired
         private IReviewService reviewService;
 
-        @PreAuthorize("isAuthenticated()")
+        @Operation(summary = "Obtener todas las reseñas")
         @GetMapping
         public ResponseEntity<ApiResponse<List<ReviewResponseDto>>> findAll() {
                 List<ReviewResponseDto> response = reviewService.findAll();
                 return success(response, "Listado de reseñas");
         }
 
+        @Operation(summary = "Obtener una reseña por su ID")
+        @GetMapping("/{id}")
+        public ResponseEntity<ApiResponse<ReviewResponseDto>> findById(@PathVariable Long id) {
+                ReviewResponseDto response = reviewService.findById(id);
+                return success(response, "Detalle de la reseña");
+        }
+
+        @Operation(summary = "Obtener reseñas por nombre de usuario")
+        @GetMapping("/buscar/por-usuario/{username}")
+        public ResponseEntity<ApiResponse<List<ReviewResponseDto>>> findByUsername(@PathVariable String username) {
+                List<ReviewResponseDto> response = reviewService.findAllByUsername(username);
+                return success(response, "Reseñas del usuario: " + username);
+        }
+
+        @Operation(summary = "Obtener reseñas por ID del cortometraje")
+        @GetMapping("/buscar/por-cortometraje/{cortometrajeId}")
+        public ResponseEntity<ApiResponse<List<ReviewResponseDto>>> findByCortometraje(
+                        @PathVariable Long cortometrajeId) {
+                List<ReviewResponseDto> response = reviewService.findAllByCortometrajeId(cortometrajeId);
+                return success(response, "Reseñas del cortometraje ID: " + cortometrajeId);
+        }
+
+        @Operation(summary = "Obtener reseñas del usuario autenticado")
         @PreAuthorize("hasAuthority('ROLE_USER')")
         @GetMapping("/mis-reviews")
         public ResponseEntity<ApiResponse<List<ReviewResponseDto>>> findMyReviews() {
@@ -36,13 +62,7 @@ public class ReviewRestcontroller extends BaseRestcontroller {
                 return success(response, "Reseñas del usuario autenticado");
         }
 
-        @PreAuthorize("isAuthenticated()")
-        @GetMapping("/{id}")
-        public ResponseEntity<ApiResponse<ReviewResponseDto>> findById(@PathVariable Long id) {
-                ReviewResponseDto response = reviewService.findById(id);
-                return success(response, "Detalle de la reseña");
-        }
-
+        @Operation(summary = "Crear una nueva reseña")
         @PreAuthorize("hasAuthority('ROLE_USER')")
         @PostMapping
         public ResponseEntity<ApiResponse<ReviewResponseDto>> create(@RequestBody @Valid ReviewRequestDto dto) {
@@ -50,6 +70,7 @@ public class ReviewRestcontroller extends BaseRestcontroller {
                 return created(response, "Reseña creada correctamente");
         }
 
+        @Operation(summary = "Actualizar una reseña (dueño o admin)")
         @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN')")
         @PutMapping("/{id}")
         public ResponseEntity<ApiResponse<ReviewResponseDto>> update(@PathVariable Long id,
@@ -58,6 +79,7 @@ public class ReviewRestcontroller extends BaseRestcontroller {
                 return success(response, "Reseña actualizada correctamente");
         }
 
+        @Operation(summary = "Eliminar una reseña (dueño o admin)")
         @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN')")
         @DeleteMapping("/{id}")
         public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id) {


### PR DESCRIPTION
Se ha implementado la lógica de eliminación lógica (soft delete) para las entidades Review y Favorite:

Al eliminar una review o un favorito se marcan los campos:

isActive = false

isDeleted = true

Se ha ajustado el método actualizarRatingCortometraje(Long) para tener en cuenta solo las reviews activas.

Se han actualizado los métodos findAllByUsername, findAll, y findAllByCortometrajeId en ReviewService para excluir reseñas eliminadas o inactivas.

Se ha actualizado el listado de favoritos para mostrar solo los activos y no eliminados, y cuyo cortometraje y autor también estén activos.

Refactorizado el método deleteFavoriteIfOwnerOrAdmin para aplicar soft delete en lugar de eliminar directamente.

Este cambio permite preservar datos históricos y facilita su restauración si es necesario.