### PR TITLE
Remove unused methods

### DIFF
--- a/src/main/java/indimetra/modelo/service/Favorite/FavoriteServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/Favorite/FavoriteServiceImplMy8.java
@@ -63,11 +63,6 @@ public class FavoriteServiceImplMy8
     // ============================================================
 
     @Override
-    public boolean isFavoriteOwner(Long userId, Long cortometrajeId) {
-        return favoriteRepository.findByUserIdAndCortometrajeId(userId, cortometrajeId).isPresent();
-    }
-
-    @Override
     public List<Favorite> findByUserId(Long userId) {
         if (userId == null || userId <= 0) {
             throw new BadRequestException("El ID del usuario no puede ser nulo o menor a 1");

--- a/src/main/java/indimetra/modelo/service/Favorite/IFavoriteService.java
+++ b/src/main/java/indimetra/modelo/service/Favorite/IFavoriteService.java
@@ -41,15 +41,6 @@ public interface IFavoriteService extends IGenericDtoService<Favorite, FavoriteR
      */
     List<FavoriteResponseDto> findAllByUsername(String username);
 
-    /**
-     * Verifica si el usuario es propietario del favorito de un cortometraje.
-     *
-     * @param userId         ID del usuario
-     * @param cortometrajeId ID del cortometraje
-     * @return true si el favorito existe y pertenece al usuario
-     */
-    boolean isFavoriteOwner(Long userId, Long cortometrajeId);
-
     // ============================================================
     // ➕ CREACIÓN Y RESTAURACIÓN
     // ============================================================

--- a/src/main/java/indimetra/modelo/service/User/IUserService.java
+++ b/src/main/java/indimetra/modelo/service/User/IUserService.java
@@ -144,13 +144,6 @@ public interface IUserService extends IGenericDtoService<User, UserRequestDto, U
     // 🗑️ ELIMINACIÓN Y RESTAURACIÓN
     // ============================================================
 
-    /**
-     * Elimina un usuario si el solicitante no es admin eliminándose a sí mismo.
-     *
-     * @param id              ID del usuario a eliminar
-     * @param currentUsername usuario autenticado que solicita la acción
-     */
-    void deleteIfNotAdmin(Long id, String currentUsername);
 
     /**
      * Realiza una eliminación lógica del usuario (soft delete).

--- a/src/main/java/indimetra/modelo/service/User/UserServiceImplMy8.java
+++ b/src/main/java/indimetra/modelo/service/User/UserServiceImplMy8.java
@@ -445,20 +445,6 @@ public class UserServiceImplMy8
         applyCascadeSoftDelete(user);
     }
 
-    @Override
-    public void deleteIfNotAdmin(Long id, String username) {
-        User user = userRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("Usuario no encontrado con ID: " + id));
-
-        boolean isAdmin = user.getRoles().stream()
-                .anyMatch(r -> r.getName().name().equals("ROLE_ADMIN"));
-
-        if (isAdmin) {
-            throw new BadRequestException("No se puede eliminar a un administrador");
-        }
-
-        userRepository.deleteById(id);
-    }
 
     // Método auxiliar para lógica en cascada
     private void applyCascadeSoftDelete(User user) {


### PR DESCRIPTION
## Summary
- remove unused `deleteIfNotAdmin` method from `UserService` interface and implementation
- remove unused `isFavoriteOwner` method from `FavoriteService` interface and implementation

## Testing
- `sh ./mvnw -q -DskipTests package` *(fails: Permission denied / network issue)*

------
https://chatgpt.com/codex/tasks/task_e_684480419e0883248e285ad2da1d34f1